### PR TITLE
Add MQ transfer API skeleton

### DIFF
--- a/api/handlers/transfer.go
+++ b/api/handlers/transfer.go
@@ -1,0 +1,212 @@
+package handlers
+
+import (
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"mq-transfer-go/api/models"
+	"mq-transfer-go/internal/mqutils"
+	"mq-transfer-go/internal/transfer"
+)
+
+var (
+	transferStatuses = make(map[string]models.TransferStatus)
+	transferManagers = make(map[string]*transfer.TransferManager)
+	statusMutex      = &sync.RWMutex{}
+)
+
+// @Summary Iniciar transferência de mensagens MQ
+// @Description Inicia uma transferência de mensagens de uma fila MQ para outra
+// @Tags transfer
+// @Accept json
+// @Produce json
+// @Param request body models.TransferRequest true "Detalhes da transferência"
+// @Success 202 {object} models.TransferResponse "Transferência iniciada"
+// @Failure 400 {object} models.TransferResponse "Erro na requisição"
+// @Failure 500 {object} models.TransferResponse "Erro interno"
+// @Router /api/v1/transfer [post]
+func StartTransfer(c *gin.Context) {
+	var request models.TransferRequest
+	if err := c.ShouldBindJSON(&request); err != nil {
+		c.JSON(http.StatusBadRequest, models.TransferResponse{
+			Status: "failed",
+			Error:  "Erro ao processar requisição: " + err.Error(),
+		})
+		return
+	}
+
+	requestID := uuid.New().String()
+
+	if request.BufferSize <= 0 {
+		request.BufferSize = 1048576
+	}
+
+	options := transfer.TransferOptions{
+		SourceConfig: mqutils.MQConnectionConfig{
+			QueueManagerName:    request.Source.QueueManagerName,
+			ConnectionName:      request.Source.ConnectionName,
+			Channel:             request.Source.Channel,
+			Username:            request.Source.Username,
+			Password:            request.Source.Password,
+			NonSharedConnection: request.NonSharedConnection,
+		},
+		SourceQueue: request.SourceQueue,
+		DestConfig: mqutils.MQConnectionConfig{
+			QueueManagerName: request.Destination.QueueManagerName,
+			ConnectionName:   request.Destination.ConnectionName,
+			Channel:          request.Destination.Channel,
+			Username:         request.Destination.Username,
+			Password:         request.Destination.Password,
+		},
+		DestQueue:           request.DestinationQueue,
+		BufferSize:          request.BufferSize,
+		CommitInterval:      request.CommitInterval,
+		NonSharedConnection: request.NonSharedConnection,
+	}
+
+	transferMgr := transfer.NewTransferManager(options)
+	transferMgr.Start()
+
+	status := models.TransferStatus{
+		RequestID:           requestID,
+		Status:              "in_progress",
+		StartTime:           time.Now().UTC().Format(time.RFC3339),
+		MessagesTransferred: 0,
+	}
+
+	statusMutex.Lock()
+	transferStatuses[requestID] = status
+	transferManagers[requestID] = transferMgr
+	statusMutex.Unlock()
+
+	go monitorTransfer(requestID, transferMgr)
+
+	c.JSON(http.StatusAccepted, models.TransferResponse{
+		RequestID: requestID,
+		Status:    "in_progress",
+	})
+}
+
+func monitorTransfer(requestID string, transferMgr *transfer.TransferManager) {
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		<-ticker.C
+
+		stats := transferMgr.GetStats()
+
+		statusMutex.Lock()
+		status := transferStatuses[requestID]
+		status.MessagesTransferred = int(stats.MessagesTransferred)
+		status.BytesTransferred = stats.BytesTransferred
+		status.Status = stats.Status
+
+		if stats.Status == "completed" || stats.Status == "failed" {
+			status.EndTime = stats.EndTime.UTC().Format(time.RFC3339)
+			status.Error = stats.Error
+			transferStatuses[requestID] = status
+			delete(transferManagers, requestID)
+			statusMutex.Unlock()
+			return
+		}
+
+		transferStatuses[requestID] = status
+		statusMutex.Unlock()
+	}
+}
+
+// @Summary Obter status da transferência
+// @Description Retorna o status atual de uma transferência de mensagens
+// @Tags transfer
+// @Produce json
+// @Param requestId path string true "ID da requisição de transferência"
+// @Success 200 {object} models.TransferStatus "Status da transferência"
+// @Failure 404 {object} models.TransferResponse "Transferência não encontrada"
+// @Router /api/v1/transfer/{requestId} [get]
+func GetTransferStatus(c *gin.Context) {
+	requestID := c.Param("requestId")
+
+	statusMutex.RLock()
+	status, exists := transferStatuses[requestID]
+	statusMutex.RUnlock()
+
+	if !exists {
+		c.JSON(http.StatusNotFound, models.TransferResponse{
+			Status: "failed",
+			Error:  "Transferência não encontrada",
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, status)
+}
+
+// @Summary Listar todas as transferências
+// @Description Retorna uma lista com todas as transferências e seus status
+// @Tags transfer
+// @Produce json
+// @Success 200 {array} models.TransferStatus "Lista de transferências"
+// @Router /api/v1/transfers [get]
+func ListTransfers(c *gin.Context) {
+	statusMutex.RLock()
+	defer statusMutex.RUnlock()
+
+	transfers := make([]models.TransferStatus, 0, len(transferStatuses))
+	for _, status := range transferStatuses {
+		transfers = append(transfers, status)
+	}
+
+	c.JSON(http.StatusOK, transfers)
+}
+
+// @Summary Cancelar uma transferência em andamento
+// @Description Cancela uma transferência de mensagens que está em andamento
+// @Tags transfer
+// @Produce json
+// @Param requestId path string true "ID da requisição de transferência"
+// @Success 200 {object} models.TransferResponse "Transferência cancelada"
+// @Failure 404 {object} models.TransferResponse "Transferência não encontrada"
+// @Failure 400 {object} models.TransferResponse "Transferência já concluída"
+// @Router /api/v1/transfer/{requestId}/cancel [post]
+func CancelTransfer(c *gin.Context) {
+	requestID := c.Param("requestId")
+
+	statusMutex.Lock()
+	defer statusMutex.Unlock()
+
+	status, exists := transferStatuses[requestID]
+	if !exists {
+		c.JSON(http.StatusNotFound, models.TransferResponse{
+			Status: "failed",
+			Error:  "Transferência não encontrada",
+		})
+		return
+	}
+
+	if status.Status != "in_progress" {
+		c.JSON(http.StatusBadRequest, models.TransferResponse{
+			Status:    "failed",
+			Error:     "Transferência já concluída ou falhou",
+			RequestID: requestID,
+		})
+		return
+	}
+
+	transferMgr, exists := transferManagers[requestID]
+	if exists {
+		transferMgr.Stop()
+		status.Status = "cancelled"
+		status.EndTime = time.Now().UTC().Format(time.RFC3339)
+		transferStatuses[requestID] = status
+		delete(transferManagers, requestID)
+	}
+
+	c.JSON(http.StatusOK, models.TransferResponse{
+		Status:    "cancelled",
+		RequestID: requestID,
+	})
+}

--- a/api/models/models.go
+++ b/api/models/models.go
@@ -1,0 +1,48 @@
+package models
+
+// ConnectionDetails contém os detalhes de conexão para um Queue Manager MQ
+type ConnectionDetails struct {
+	QueueManagerName string `json:"queueManagerName" binding:"required" example:"QM1" swaggertype:"string"`
+	ConnectionName   string `json:"connectionName" binding:"required" example:"localhost(1414)" swaggertype:"string"`
+	Channel          string `json:"channel" binding:"required" example:"SYSTEM.DEF.SVRCONN" swaggertype:"string"`
+	Username         string `json:"username,omitempty" example:"mquser" swaggertype:"string"`
+	Password         string `json:"password,omitempty" example:"mqpassword" swaggertype:"string"`
+}
+
+// TransferRequest representa o payload para uma solicitação de transferência de mensagens
+type TransferRequest struct {
+	Source              ConnectionDetails `json:"source" binding:"required"`
+	SourceQueue         string            `json:"sourceQueue" binding:"required" example:"SOURCE.QUEUE" swaggertype:"string"`
+	Destination         ConnectionDetails `json:"destination" binding:"required"`
+	DestinationQueue    string            `json:"destinationQueue" binding:"required" example:"DEST.QUEUE" swaggertype:"string"`
+	BufferSize          int               `json:"bufferSize,omitempty" example:"1048576" swaggertype:"integer"`
+	NonSharedConnection bool              `json:"nonSharedConnection,omitempty" example:"false" swaggertype:"boolean"`
+	CommitInterval      int               `json:"commitInterval,omitempty" example:"10" swaggertype:"integer"`
+}
+
+// TransferResponse representa a resposta de uma operação de transferência
+type TransferResponse struct {
+	RequestID           string `json:"requestId" example:"550e8400-e29b-41d4-a716-446655440000" swaggertype:"string"`
+	Status              string `json:"status" example:"in_progress" swaggertype:"string"`
+	MessagesTotal       int    `json:"messagesTotal,omitempty" example:"1000" swaggertype:"integer"`
+	MessagesTransferred int    `json:"messagesTransferred,omitempty" example:"500" swaggertype:"integer"`
+	Error               string `json:"error,omitempty" example:"Failed to connect to source queue manager" swaggertype:"string"`
+}
+
+// TransferStatus representa o status atual de uma transferência em andamento
+type TransferStatus struct {
+	RequestID           string `json:"requestId" example:"550e8400-e29b-41d4-a716-446655440000" swaggertype:"string"`
+	Status              string `json:"status" example:"in_progress" swaggertype:"string"`
+	StartTime           string `json:"startTime" example:"2025-06-04T00:15:30Z" swaggertype:"string"`
+	EndTime             string `json:"endTime,omitempty" example:"2025-06-04T00:16:45Z" swaggertype:"string"`
+	MessagesTotal       int    `json:"messagesTotal,omitempty" example:"1000" swaggertype:"integer"`
+	MessagesTransferred int    `json:"messagesTransferred" example:"500" swaggertype:"integer"`
+	BytesTransferred    int64  `json:"bytesTransferred" example:"1048576" swaggertype:"integer"`
+	Error               string `json:"error,omitempty" example:"Failed to connect to source queue manager" swaggertype:"string"`
+}
+
+// HealthResponse representa a resposta do endpoint de health check
+type HealthResponse struct {
+	Status  string `json:"status" example:"ok" swaggertype:"string"`
+	Version string `json:"version" example:"1.0.0" swaggertype:"string"`
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,66 @@
+module mq-transfer-go
+
+go 1.22.0
+
+require (
+    github.com/gin-gonic/gin v1.10.1
+    github.com/google/uuid v1.6.0
+    github.com/ibm-messaging/mq-golang/v5 v5.6.3
+    github.com/swaggo/files v1.0.1
+    github.com/swaggo/gin-swagger v1.6.0
+    github.com/swaggo/swag v1.16.4
+    go.opentelemetry.io/otel v1.36.0
+    go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.36.0
+    go.opentelemetry.io/otel/metric v1.36.0
+    go.opentelemetry.io/otel/sdk v1.36.0
+    go.opentelemetry.io/otel/sdk/metric v1.36.0
+)
+
+require (
+    github.com/KyleBanks/depth v1.2.1 // indirect
+    github.com/PuerkitoBio/purell v1.1.1 // indirect
+    github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
+    github.com/bytedance/sonic v1.11.6 // indirect
+    github.com/cenkalti/backoff/v5 v5.0.2 // indirect
+    github.com/chenzhuoyu/base64x v0.0.0-20230717121745-296ad89f973d // indirect
+    github.com/chenzhuoyu/iasm v0.9.1 // indirect
+    github.com/gabriel-vasile/mimetype v1.4.3 // indirect
+    github.com/gin-contrib/sse v0.1.0 // indirect
+    github.com/go-logr/logr v1.4.2 // indirect
+    github.com/go-logr/stdr v1.2.2 // indirect
+    github.com/go-openapi/jsonpointer v0.19.5 // indirect
+    github.com/go-openapi/jsonreference v0.19.6 // indirect
+    github.com/go-openapi/spec v0.20.4 // indirect
+    github.com/go-openapi/swag v0.19.15 // indirect
+    github.com/go-playground/locales v0.14.1 // indirect
+    github.com/go-playground/universal-translator v0.18.1 // indirect
+    github.com/go-playground/validator/v10 v10.20.0 // indirect
+    github.com/goccy/go-json v0.10.2 // indirect
+    github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3 // indirect
+    github.com/josharian/intern v1.0.0 // indirect
+    github.com/json-iterator/go v1.1.12 // indirect
+    github.com/klauspost/cpuid/v2 v2.2.7 // indirect
+    github.com/leodido/go-urn v1.4.0 // indirect
+    github.com/mailru/easyjson v0.7.6 // indirect
+    github.com/mattn/go-isatty v0.0.20 // indirect
+    github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+    github.com/modern-go/reflect2 v1.0.2 // indirect
+    github.com/pelletier/go-toml/v2 v2.2.2 // indirect
+    github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
+    github.com/ugorji/go/codec v1.2.12 // indirect
+    go.opentelemetry.io/otel/trace v1.36.0 // indirect
+    go.opentelemetry.io/proto/otlp v1.6.0 // indirect
+    golang.org/x/arch v0.8.0 // indirect
+    golang.org/x/crypto v0.21.0 // indirect
+    golang.org/x/net v0.22.0 // indirect
+    golang.org/x/sys v0.18.0 // indirect
+    golang.org/x/text v0.14.0 // indirect
+    golang.org/x/tools v0.19.0 // indirect
+    google.golang.org/genproto/googleapis/api v0.0.0-20240318140521-94a12d6c2237 // indirect
+    google.golang.org/genproto/googleapis/rpc v0.0.0-20240318140521-94a12d6c2237 // indirect
+    google.golang.org/grpc v1.62.1 // indirect
+    google.golang.org/protobuf v1.33.0 // indirect
+    gopkg.in/yaml.v2 v2.4.0 // indirect
+    gopkg.in/yaml.v3 v3.0.1 // indirect
+)
+

--- a/internal/mqutils/mqutils.go
+++ b/internal/mqutils/mqutils.go
@@ -1,0 +1,184 @@
+package mqutils
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/ibm-messaging/mq-golang/v5/ibmmq"
+)
+
+// MQConnectionConfig contém os parâmetros de conexão para um Queue Manager MQ
+type MQConnectionConfig struct {
+	QueueManagerName    string
+	ConnectionName      string
+	Channel             string
+	Username            string
+	Password            string
+	NonSharedConnection bool
+}
+
+// MQConnection encapsula uma conexão com um Queue Manager MQ
+type MQConnection struct {
+	QMgr        ibmmq.MQQueueManager
+	Config      MQConnectionConfig
+	IsConnected bool
+}
+
+// NewMQConnection cria uma nova instância de MQConnection
+func NewMQConnection(config MQConnectionConfig) *MQConnection {
+	return &MQConnection{
+		Config:      config,
+		IsConnected: false,
+	}
+}
+
+// Connect estabelece uma conexão com o Queue Manager MQ
+func (conn *MQConnection) Connect() error {
+	cd := ibmmq.NewMQCD()
+	cd.ChannelName = conn.Config.Channel
+	cd.ConnectionName = conn.Config.ConnectionName
+
+	cno := ibmmq.NewMQCNO()
+	cno.ClientConn = cd
+
+	if conn.Config.Username != "" {
+		csp := ibmmq.NewMQCSP()
+		csp.UserId = conn.Config.Username
+		csp.Password = conn.Config.Password
+		cno.SecurityParms = csp
+	}
+
+	var err error
+	conn.QMgr, err = ibmmq.Connx(conn.Config.QueueManagerName, cno)
+	if err != nil {
+		return fmt.Errorf("falha ao conectar ao Queue Manager %s: %v", conn.Config.QueueManagerName, err)
+	}
+
+	conn.IsConnected = true
+	return nil
+}
+
+// Disconnect fecha a conexão com o Queue Manager MQ
+func (conn *MQConnection) Disconnect() error {
+	if !conn.IsConnected {
+		return nil
+	}
+
+	err := conn.QMgr.Disc()
+	if err != nil {
+		return fmt.Errorf("falha ao desconectar do Queue Manager: %v", err)
+	}
+
+	conn.IsConnected = false
+	return nil
+}
+
+// OpenQueue abre uma fila MQ para leitura ou escrita
+func (conn *MQConnection) OpenQueue(queueName string, forInput bool, nonShared bool) (ibmmq.MQObject, error) {
+	if !conn.IsConnected {
+		return ibmmq.MQObject{}, fmt.Errorf("não conectado ao Queue Manager")
+	}
+
+	var openOptions int32
+	if forInput {
+		openOptions = ibmmq.MQOO_INPUT_SHARED | ibmmq.MQOO_FAIL_IF_QUIESCING
+		if nonShared {
+			openOptions = ibmmq.MQOO_INPUT_EXCLUSIVE | ibmmq.MQOO_FAIL_IF_QUIESCING
+		}
+	} else {
+		openOptions = ibmmq.MQOO_OUTPUT | ibmmq.MQOO_FAIL_IF_QUIESCING
+	}
+
+	od := ibmmq.NewMQOD()
+	od.ObjectName = queueName
+	od.ObjectType = ibmmq.MQOT_Q
+
+	queue, err := conn.QMgr.Open(od, openOptions)
+	if err != nil {
+		return ibmmq.MQObject{}, fmt.Errorf("falha ao abrir a fila %s: %v", queueName, err)
+	}
+
+	return queue, nil
+}
+
+// CloseQueue fecha uma fila MQ
+func (conn *MQConnection) CloseQueue(queue ibmmq.MQObject) error {
+	err := queue.Close(0)
+	if err != nil {
+		return fmt.Errorf("falha ao fechar a fila: %v", err)
+	}
+	return nil
+}
+
+// GetMessage obtém uma mensagem de uma fila MQ
+func (conn *MQConnection) GetMessage(queue ibmmq.MQObject, bufferSize int, waitInterval int) ([]byte, *ibmmq.MQMD, error) {
+	md := ibmmq.NewMQMD()
+
+	gmo := ibmmq.NewMQGMO()
+	gmo.Options = ibmmq.MQGMO_WAIT | ibmmq.MQGMO_FAIL_IF_QUIESCING
+	if waitInterval > 0 {
+		gmo.Options |= ibmmq.MQGMO_SYNCPOINT
+	} else {
+		gmo.Options |= ibmmq.MQGMO_NO_SYNCPOINT
+	}
+	gmo.WaitInterval = 5 * 1000
+
+	buffer := make([]byte, bufferSize)
+
+	datalen, err := queue.Get(md, gmo, buffer)
+	if err != nil {
+		mqrc := err.(*ibmmq.MQReturn).MQRC
+		if mqrc == ibmmq.MQRC_NO_MSG_AVAILABLE {
+			return nil, nil, nil
+		}
+		return nil, nil, fmt.Errorf("falha ao obter mensagem: %v", err)
+	}
+
+	return buffer[:datalen], md, nil
+}
+
+// PutMessage coloca uma mensagem em uma fila MQ, preservando o contexto da mensagem original
+func (conn *MQConnection) PutMessage(queue ibmmq.MQObject, data []byte, md *ibmmq.MQMD, commitInterval int) error {
+	pmo := ibmmq.NewMQPMO()
+	if commitInterval > 0 {
+		pmo.Options |= ibmmq.MQPMO_SYNCPOINT
+	} else {
+		pmo.Options |= ibmmq.MQPMO_NO_SYNCPOINT
+	}
+	pmo.Options |= ibmmq.MQPMO_PASS_ALL_CONTEXT
+
+	err := queue.Put(md, pmo, data)
+	if err != nil {
+		return fmt.Errorf("falha ao colocar mensagem: %v", err)
+	}
+
+	return nil
+}
+
+// Commit realiza um commit da transação atual
+func (conn *MQConnection) Commit() error {
+	if !conn.IsConnected {
+		return fmt.Errorf("não conectado ao Queue Manager")
+	}
+
+	err := conn.QMgr.Cmit()
+	if err != nil {
+		return fmt.Errorf("falha ao realizar commit: %v", err)
+	}
+
+	return nil
+}
+
+// Backout realiza um backout da transação atual
+func (conn *MQConnection) Backout() error {
+	if !conn.IsConnected {
+		return fmt.Errorf("não conectado ao Queue Manager")
+	}
+
+	err := conn.QMgr.Back()
+	if err != nil {
+		return fmt.Errorf("falha ao realizar backout: %v", err)
+	}
+
+	return nil
+}

--- a/internal/otelutils/otelutils.go
+++ b/internal/otelutils/otelutils.go
@@ -1,0 +1,165 @@
+package otelutils
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
+	"go.opentelemetry.io/otel/metric"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/aggregation"
+	"go.opentelemetry.io/otel/sdk/resource"
+	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
+)
+
+// MQMetrics contém os medidores para métricas relacionadas à transferência MQ
+type MQMetrics struct {
+	MessagesTransferred metric.Int64Counter
+	BytesTransferred    metric.Int64Counter
+	TransferDuration    metric.Float64Histogram
+	CommitCounter       metric.Int64Counter
+	ErrorCounter        metric.Int64Counter
+	Meter               metric.Meter
+}
+
+// OTelConfig contém a configuração para o OpenTelemetry
+type OTelConfig struct {
+	ServiceName    string
+	ServiceVersion string
+	Environment    string
+	OTLPEndpoint   string
+}
+
+var (
+	mp      *sdkmetric.MeterProvider
+	metrics *MQMetrics
+)
+
+// InitOTel inicializa o OpenTelemetry SDK
+func InitOTel(config OTelConfig) (*MQMetrics, error) {
+	res, err := resource.Merge(
+		resource.Default(),
+		resource.NewWithAttributes(
+			semconv.SchemaURL,
+			semconv.ServiceName(config.ServiceName),
+			semconv.ServiceVersion(config.ServiceVersion),
+			semconv.DeploymentEnvironment(config.Environment),
+		),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("falha ao criar recurso: %v", err)
+	}
+
+	ctx := context.Background()
+	exp, err := otlpmetricgrpc.New(ctx,
+		otlpmetricgrpc.WithEndpoint(config.OTLPEndpoint),
+		otlpmetricgrpc.WithInsecure(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("falha ao criar exportador OTLP: %v", err)
+	}
+
+	mp = sdkmetric.NewMeterProvider(
+		sdkmetric.WithResource(res),
+		sdkmetric.WithReader(
+			sdkmetric.NewPeriodicReader(
+				exp,
+				sdkmetric.WithInterval(10*time.Second),
+				sdkmetric.WithTimeout(5*time.Second),
+			),
+		),
+		sdkmetric.WithView(
+			sdkmetric.NewView(
+				sdkmetric.Instrument{
+					Name: "mq_transfer_duration",
+					Kind: sdkmetric.InstrumentKindHistogram,
+				},
+				sdkmetric.Stream{
+					Aggregation: aggregation.ExplicitBucketHistogram{
+						Boundaries: []float64{
+							1, 5, 10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000,
+						},
+					},
+				},
+			),
+		),
+	)
+
+	otel.SetMeterProvider(mp)
+
+	meter := mp.Meter("mq-transfer-service")
+
+	messagesCounter, err := meter.Int64Counter(
+		"mq_messages_transferred",
+		metric.WithDescription("Número total de mensagens transferidas"),
+		metric.WithUnit("{messages}"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("falha ao criar contador de mensagens: %v", err)
+	}
+
+	bytesCounter, err := meter.Int64Counter(
+		"mq_bytes_transferred",
+		metric.WithDescription("Número total de bytes transferidos"),
+		metric.WithUnit("By"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("falha ao criar contador de bytes: %v", err)
+	}
+
+	durationHistogram, err := meter.Float64Histogram(
+		"mq_transfer_duration",
+		metric.WithDescription("Duração da transferência de mensagens"),
+		metric.WithUnit("ms"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("falha ao criar histograma de duração: %v", err)
+	}
+
+	commitCounter, err := meter.Int64Counter(
+		"mq_commits",
+		metric.WithDescription("Número total de commits realizados"),
+		metric.WithUnit("{commits}"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("falha ao criar contador de commits: %v", err)
+	}
+
+	errorCounter, err := meter.Int64Counter(
+		"mq_errors",
+		metric.WithDescription("Número total de erros ocorridos"),
+		metric.WithUnit("{errors}"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("falha ao criar contador de erros: %v", err)
+	}
+
+	metrics = &MQMetrics{
+		MessagesTransferred: messagesCounter,
+		BytesTransferred:    bytesCounter,
+		TransferDuration:    durationHistogram,
+		CommitCounter:       commitCounter,
+		ErrorCounter:        errorCounter,
+		Meter:               meter,
+	}
+
+	log.Println("OpenTelemetry inicializado com sucesso")
+	return metrics, nil
+}
+
+// Shutdown encerra o provedor de métricas
+func Shutdown(ctx context.Context) {
+	if mp != nil {
+		if err := mp.Shutdown(ctx); err != nil {
+			log.Printf("Erro ao encerrar o provedor de métricas: %v", err)
+		}
+	}
+}
+
+// GetMetrics retorna as métricas configuradas
+func GetMetrics() *MQMetrics {
+	return metrics
+}

--- a/main.go
+++ b/main.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"context"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	swaggerFiles "github.com/swaggo/files"
+	ginSwagger "github.com/swaggo/gin-swagger"
+	_ "mq-transfer-go/api/docs"
+	"mq-transfer-go/api/handlers"
+	"mq-transfer-go/internal/otelutils"
+)
+
+// @title MQ Transfer API
+// @version 1.0
+// @description API para transferência de mensagens entre filas IBM MQ
+// @termsOfService http://swagger.io/terms/
+// @contact.name API Support
+// @contact.url http://www.example.com/support
+// @contact.email support@example.com
+// @license.name Apache 2.0
+// @license.url http://www.apache.org/licenses/LICENSE-2.0.html
+// @host localhost:8080
+// @BasePath /
+// @schemes http
+func main() {
+	otelConfig := otelutils.OTelConfig{
+		ServiceName:    "mq-transfer-service",
+		ServiceVersion: "1.0.0",
+		Environment:    os.Getenv("ENV"),
+		OTLPEndpoint:   os.Getenv("OTLP_ENDPOINT"),
+	}
+	if otelConfig.OTLPEndpoint == "" {
+		otelConfig.OTLPEndpoint = "localhost:4317"
+	}
+	if otelConfig.Environment == "" {
+		otelConfig.Environment = "development"
+	}
+	_, err := otelutils.InitOTel(otelConfig)
+	if err != nil {
+		log.Printf("Aviso: Falha ao inicializar OpenTelemetry: %v. Continuando sem telemetria.", err)
+	}
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	r := gin.Default()
+	v1 := r.Group("/api/v1")
+	{
+		v1.POST("/transfer", handlers.StartTransfer)
+		v1.GET("/transfer/:requestId", handlers.GetTransferStatus)
+		v1.GET("/transfers", handlers.ListTransfers)
+		v1.POST("/transfer/:requestId/cancel", handlers.CancelTransfer)
+		v1.GET("/health", func(c *gin.Context) {
+			c.JSON(200, gin.H{
+				"status":  "ok",
+				"version": "1.0.0",
+			})
+		})
+	}
+	r.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
+
+	srv := &http.Server{
+		Addr:    ":8080",
+		Handler: r,
+	}
+
+	go func() {
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Fatalf("Falha ao iniciar o servidor: %v", err)
+		}
+	}()
+
+	log.Println("Servidor iniciado na porta 8080")
+	log.Println("Documentação Swagger disponível em: http://localhost:8080/swagger/index.html")
+
+	<-ctx.Done()
+	log.Println("Desligando servidor...")
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := srv.Shutdown(shutdownCtx); err != nil {
+		log.Fatalf("Erro ao desligar o servidor: %v", err)
+	}
+
+	otelutils.Shutdown(shutdownCtx)
+
+	log.Println("Servidor encerrado com sucesso")
+}


### PR DESCRIPTION
## Summary
- implement service entrypoint with REST routes and OTEL setup
- define request/response models for transfers
- add basic MQ utility functions
- add OpenTelemetry helpers
- implement handlers for transfer operations
- declare module requirements

## Testing
- `go test ./...` *(fails: missing modules & network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_683fa6970ac48325a62e3210d94229b2