### PR TITLE
Fix metrics shutdown error when OTLP endpoint missing

### DIFF
--- a/internal/otelutils/otelutils.go
+++ b/internal/otelutils/otelutils.go
@@ -11,7 +11,7 @@ import (
 	"go.opentelemetry.io/otel/metric"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
-	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 )
 
 // MQMetrics contém os medidores para métricas relacionadas à transferência MQ
@@ -39,6 +39,13 @@ var (
 
 // InitOTel inicializa o OpenTelemetry SDK
 func InitOTel(config OTelConfig) (*MQMetrics, error) {
+	if config.OTLPEndpoint == "" {
+		log.Println("OTLP endpoint não configurado; telemetria desativada")
+		mp = nil
+		metrics = nil
+		return nil, nil
+	}
+
 	res, err := resource.Merge(
 		resource.Default(),
 		resource.NewWithAttributes(

--- a/main.go
+++ b/main.go
@@ -36,9 +36,6 @@ func main() {
 		Environment:    os.Getenv("ENV"),
 		OTLPEndpoint:   os.Getenv("OTLP_ENDPOINT"),
 	}
-	if otelConfig.OTLPEndpoint == "" {
-		otelConfig.OTLPEndpoint = "localhost:4317"
-	}
 	if otelConfig.Environment == "" {
 		otelConfig.Environment = "development"
 	}


### PR DESCRIPTION
## Summary
- avoid configuring OTLP exporter if `OTLP_ENDPOINT` is not defined
- stop defaulting to `localhost:4317`

## Testing
- `GOPROXY=direct go vet ./...`
- `GOPROXY=direct go build ./...`
- `GOPROXY=direct go test ./...`
- `GOPROXY=direct go run ./...` *(terminated with Ctrl+C)*

------
https://chatgpt.com/codex/tasks/task_e_683fa9b8a19483259c508219c4541e48