### PR TITLE
Fix Swagger doc error with minimal spec

### DIFF
--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -1,3 +1,41 @@
 package docs
 
-// This package is a placeholder for Swagger documentation.
+import "github.com/swaggo/swag"
+
+const docTemplate = `{
+    "swagger": "2.0",
+    "info": {
+        "description": "API para transferência de mensagens entre filas IBM MQ",
+        "title": "MQ Transfer API",
+        "termsOfService": "http://swagger.io/terms/",
+        "contact": {
+            "name": "API Support",
+            "url": "http://www.example.com/support",
+            "email": "support@example.com"
+        },
+        "license": {
+            "name": "Apache 2.0",
+            "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+        },
+        "version": "1.0"
+    },
+    "host": "localhost:8080",
+    "basePath": "/",
+    "schemes": ["http"],
+    "paths": {}
+}`
+
+var SwaggerInfo = &swag.Spec{
+	Version:          "1.0",
+	Host:             "localhost:8080",
+	BasePath:         "/",
+	Schemes:          []string{"http"},
+	Title:            "MQ Transfer API",
+	Description:      "API para transferência de mensagens entre filas IBM MQ",
+	InfoInstanceName: "swagger",
+	SwaggerTemplate:  docTemplate,
+}
+
+func init() {
+	swag.Register(SwaggerInfo.InstanceName(), SwaggerInfo)
+}


### PR DESCRIPTION
## Summary
- implement a basic swagger specification so `/swagger/index.html` works again

## Testing
- `go vet ./...` *(fails: forbidden module download)*

------
https://chatgpt.com/codex/tasks/task_e_683fb0c548bc83259596b67e046aae00