### PR TITLE
Fix context handle error when putting messages

### DIFF
--- a/internal/mqutils/mqutils.go
+++ b/internal/mqutils/mqutils.go
@@ -88,7 +88,10 @@ func (conn *MQConnection) OpenQueue(queueName string, forInput bool, nonShared b
 			openOptions = ibmmq.MQOO_INPUT_EXCLUSIVE | ibmmq.MQOO_FAIL_IF_QUIESCING
 		}
 	} else {
-		openOptions = ibmmq.MQOO_OUTPUT | ibmmq.MQOO_FAIL_IF_QUIESCING
+		// Include MQOO_PASS_ALL_CONTEXT so we can put messages preserving
+		// the original context. Without this option the queue manager
+		// returns MQRC_CONTEXT_HANDLE_ERROR when using MQPMO_PASS_ALL_CONTEXT.
+		openOptions = ibmmq.MQOO_OUTPUT | ibmmq.MQOO_FAIL_IF_QUIESCING | ibmmq.MQOO_PASS_ALL_CONTEXT
 	}
 
 	od := ibmmq.NewMQOD()


### PR DESCRIPTION
## Summary
- open destination queues with `MQOO_PASS_ALL_CONTEXT`
- document the reason to avoid `MQRC_CONTEXT_HANDLE_ERROR`

## Testing
- `go vet ./...` *(fails: Forbidden when downloading modules)*
- `gofmt -w internal/mqutils/mqutils.go`


------
https://chatgpt.com/codex/tasks/task_e_6841ba46c0b08325a539359ac268cc5b