### PR TITLE
Fix context handle error for MQ puts

### DIFF
--- a/internal/mqutils/mqutils.go
+++ b/internal/mqutils/mqutils.go
@@ -143,14 +143,16 @@ func (conn *MQConnection) GetMessage(queue ibmmq.MQObject, bufferSize int, waitI
 }
 
 // PutMessage coloca uma mensagem em uma fila MQ, preservando o contexto da mensagem original
-func (conn *MQConnection) PutMessage(queue ibmmq.MQObject, data []byte, md *ibmmq.MQMD, commitInterval int) error {
+func (conn *MQConnection) PutMessage(queue ibmmq.MQObject, srcQ ibmmq.MQObject, data []byte, md *ibmmq.MQMD, commitInterval int) error {
 	pmo := ibmmq.NewMQPMO()
 	if commitInterval > 0 {
 		pmo.Options |= ibmmq.MQPMO_SYNCPOINT
 	} else {
 		pmo.Options |= ibmmq.MQPMO_NO_SYNCPOINT
 	}
-	pmo.Options |= ibmmq.MQPMO_PASS_ALL_CONTEXT
+
+       pmo.Options |= ibmmq.MQPMO_PASS_ALL_CONTEXT
+       pmo.Context = &srcQ
 
 	err := queue.Put(md, pmo, data)
 	if err != nil {

--- a/internal/mqutils/mqutils_stub.go
+++ b/internal/mqutils/mqutils_stub.go
@@ -47,7 +47,7 @@ func (c *MQConnection) GetMessage(queue struct{}, bufferSize int, waitInterval i
 	return nil, nil, nil
 }
 
-func (c *MQConnection) PutMessage(queue struct{}, data []byte, md interface{}, commitInterval int) error {
+func (c *MQConnection) PutMessage(queue struct{}, srcQ struct{}, data []byte, md interface{}, commitInterval int) error {
 	return nil
 }
 

--- a/internal/transfer/transfer.go
+++ b/internal/transfer/transfer.go
@@ -110,7 +110,7 @@ func (tm *TransferManager) run() {
 				return
 			}
 
-			if err := destConn.PutMessage(destQ, data, md, tm.opts.CommitInterval); err != nil {
+                       if err := destConn.PutMessage(destQ, srcQ, data, md, tm.opts.CommitInterval); err != nil {
 				tm.finishWithError("failed", err)
 				return
 			}


### PR DESCRIPTION
## Summary
- set MQPMO context to source queue when putting messages
- update stubs and transfer manager for new parameter

## Testing
- `go build ./...` *(fails: Forbidden during module download)*

------
https://chatgpt.com/codex/tasks/task_e_6841be942ac88325b7d6fbdb3448ee15