### PR TITLE
Improve transfer cancellation and code clarity

### DIFF
--- a/api/handlers/transfer.go
+++ b/api/handlers/transfer.go
@@ -1,22 +1,25 @@
 package handlers
 
 import (
-    "net/http"
-    "sync"
-    "time"
+	"net/http"
+	"sync"
+	"time"
 
-    "github.com/gin-gonic/gin"
-    "github.com/google/uuid"
-    "mq-transfer-go/api/models"
-    "mq-transfer-go/internal/mqutils"
-    "mq-transfer-go/internal/transfer"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"mq-transfer-go/api/models"
+	"mq-transfer-go/internal/mqutils"
+	"mq-transfer-go/internal/transfer"
 )
 
 var (
-    transferStatuses = make(map[string]models.TransferStatus)
-    transferManagers = make(map[string]*transfer.TransferManager)
-    statusMutex      = &sync.RWMutex{}
+	transferStatuses = make(map[string]models.TransferStatus)
+	transferManagers = make(map[string]*transfer.TransferManager)
+	statusMutex      = &sync.RWMutex{}
 )
+
+// statusTTL defines how long finished transfer statuses are kept in memory.
+const statusTTL = 10 * time.Minute
 
 // @Summary Iniciar transferência de mensagens MQ
 // @Description Inicia uma transferência de mensagens de uma fila MQ para outra
@@ -29,94 +32,99 @@ var (
 // @Failure 500 {object} models.TransferResponse "Erro interno"
 // @Router /api/v1/transfer [post]
 func StartTransfer(c *gin.Context) {
-    var request models.TransferRequest
-    if err := c.ShouldBindJSON(&request); err != nil {
-        c.JSON(http.StatusBadRequest, models.TransferResponse{
-            Status: "failed",
-            Error:  "Erro ao processar requisição: " + err.Error(),
-        })
-        return
-    }
+	var request models.TransferRequest
+	if err := c.ShouldBindJSON(&request); err != nil {
+		c.JSON(http.StatusBadRequest, models.TransferResponse{
+			Status: transfer.StatusFailed,
+			Error:  "Erro ao processar requisição: " + err.Error(),
+		})
+		return
+	}
 
-    requestID := uuid.New().String()
+	requestID := uuid.New().String()
 
-    if request.BufferSize <= 0 {
-        request.BufferSize = 1048576
-    }
+	if request.BufferSize <= 0 {
+		request.BufferSize = 1048576
+	}
 
-    options := transfer.TransferOptions{
-        SourceConfig: mqutils.MQConnectionConfig{
-            QueueManagerName:    request.Source.QueueManagerName,
-            ConnectionName:      request.Source.ConnectionName,
-            Channel:             request.Source.Channel,
-            Username:            request.Source.Username,
-            Password:            request.Source.Password,
-            NonSharedConnection: request.NonSharedConnection,
-        },
-        SourceQueue: request.SourceQueue,
-        DestConfig: mqutils.MQConnectionConfig{
-            QueueManagerName: request.Destination.QueueManagerName,
-            ConnectionName:   request.Destination.ConnectionName,
-            Channel:          request.Destination.Channel,
-            Username:         request.Destination.Username,
-            Password:         request.Destination.Password,
-        },
-        DestQueue:           request.DestinationQueue,
-        BufferSize:          request.BufferSize,
-        CommitInterval:      request.CommitInterval,
-        NonSharedConnection: request.NonSharedConnection,
-    }
+	options := transfer.TransferOptions{
+		SourceConfig: mqutils.MQConnectionConfig{
+			QueueManagerName:    request.Source.QueueManagerName,
+			ConnectionName:      request.Source.ConnectionName,
+			Channel:             request.Source.Channel,
+			Username:            request.Source.Username,
+			Password:            request.Source.Password,
+			NonSharedConnection: request.NonSharedConnection,
+		},
+		SourceQueue: request.SourceQueue,
+		DestConfig: mqutils.MQConnectionConfig{
+			QueueManagerName: request.Destination.QueueManagerName,
+			ConnectionName:   request.Destination.ConnectionName,
+			Channel:          request.Destination.Channel,
+			Username:         request.Destination.Username,
+			Password:         request.Destination.Password,
+		},
+		DestQueue:           request.DestinationQueue,
+		BufferSize:          request.BufferSize,
+		CommitInterval:      request.CommitInterval,
+		NonSharedConnection: request.NonSharedConnection,
+	}
 
-    transferMgr := transfer.NewTransferManager(options)
-    transferMgr.Start()
+	transferMgr := transfer.NewTransferManager(options)
+	transferMgr.Start()
 
-    status := models.TransferStatus{
-        RequestID:           requestID,
-        Status:              "in_progress",
-        StartTime:           time.Now().UTC().Format(time.RFC3339),
-        MessagesTransferred: 0,
-    }
+	status := models.TransferStatus{
+		RequestID:           requestID,
+		Status:              transfer.StatusInProgress,
+		StartTime:           time.Now().UTC().Format(time.RFC3339),
+		MessagesTransferred: 0,
+	}
 
-    statusMutex.Lock()
-    transferStatuses[requestID] = status
-    transferManagers[requestID] = transferMgr
-    statusMutex.Unlock()
+	statusMutex.Lock()
+	transferStatuses[requestID] = status
+	transferManagers[requestID] = transferMgr
+	statusMutex.Unlock()
 
-    go monitorTransfer(requestID, transferMgr)
+	go monitorTransfer(requestID, transferMgr)
 
-    c.JSON(http.StatusAccepted, models.TransferResponse{
-        RequestID: requestID,
-        Status:    "in_progress",
-    })
+	c.JSON(http.StatusAccepted, models.TransferResponse{
+		RequestID: requestID,
+		Status:    transfer.StatusInProgress,
+	})
 }
 
 func monitorTransfer(requestID string, transferMgr *transfer.TransferManager) {
-    ticker := time.NewTicker(1 * time.Second)
-    defer ticker.Stop()
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
 
-    for {
-        <-ticker.C
+	for {
+		<-ticker.C
 
-        stats := transferMgr.GetStats()
+		stats := transferMgr.GetStats()
 
-        statusMutex.Lock()
-        status := transferStatuses[requestID]
-        status.MessagesTransferred = int(stats.MessagesTransferred)
-        status.BytesTransferred = stats.BytesTransferred
-        status.Status = stats.Status
+		statusMutex.Lock()
+		status := transferStatuses[requestID]
+		status.MessagesTransferred = int(stats.MessagesTransferred)
+		status.BytesTransferred = stats.BytesTransferred
+		status.Status = stats.Status
 
-        if stats.Status == "completed" || stats.Status == "failed" {
-            status.EndTime = stats.EndTime.UTC().Format(time.RFC3339)
-            status.Error = stats.Error
-            transferStatuses[requestID] = status
-            delete(transferManagers, requestID)
-            statusMutex.Unlock()
-            return
-        }
+		if stats.Status == transfer.StatusCompleted || stats.Status == transfer.StatusFailed || stats.Status == transfer.StatusCancelled {
+			status.EndTime = stats.EndTime.UTC().Format(time.RFC3339)
+			status.Error = stats.Error
+			transferStatuses[requestID] = status
+			delete(transferManagers, requestID)
+			statusMutex.Unlock()
+			time.AfterFunc(statusTTL, func() {
+				statusMutex.Lock()
+				delete(transferStatuses, requestID)
+				statusMutex.Unlock()
+			})
+			return
+		}
 
-        transferStatuses[requestID] = status
-        statusMutex.Unlock()
-    }
+		transferStatuses[requestID] = status
+		statusMutex.Unlock()
+	}
 }
 
 // @Summary Obter status da transferência
@@ -128,21 +136,21 @@ func monitorTransfer(requestID string, transferMgr *transfer.TransferManager) {
 // @Failure 404 {object} models.TransferResponse "Transferência não encontrada"
 // @Router /api/v1/transfer/{requestId} [get]
 func GetTransferStatus(c *gin.Context) {
-    requestID := c.Param("requestId")
+	requestID := c.Param("requestId")
 
-    statusMutex.RLock()
-    status, exists := transferStatuses[requestID]
-    statusMutex.RUnlock()
+	statusMutex.RLock()
+	status, exists := transferStatuses[requestID]
+	statusMutex.RUnlock()
 
-    if !exists {
-        c.JSON(http.StatusNotFound, models.TransferResponse{
-            Status: "failed",
-            Error:  "Transferência não encontrada",
-        })
-        return
-    }
+	if !exists {
+		c.JSON(http.StatusNotFound, models.TransferResponse{
+			Status: transfer.StatusFailed,
+			Error:  "Transferência não encontrada",
+		})
+		return
+	}
 
-    c.JSON(http.StatusOK, status)
+	c.JSON(http.StatusOK, status)
 }
 
 // @Summary Listar todas as transferências
@@ -152,15 +160,15 @@ func GetTransferStatus(c *gin.Context) {
 // @Success 200 {array} models.TransferStatus "Lista de transferências"
 // @Router /api/v1/transfers [get]
 func ListTransfers(c *gin.Context) {
-    statusMutex.RLock()
-    defer statusMutex.RUnlock()
+	statusMutex.RLock()
+	defer statusMutex.RUnlock()
 
-    transfers := make([]models.TransferStatus, 0, len(transferStatuses))
-    for _, status := range transferStatuses {
-        transfers = append(transfers, status)
-    }
+	transfers := make([]models.TransferStatus, 0, len(transferStatuses))
+	for _, status := range transferStatuses {
+		transfers = append(transfers, status)
+	}
 
-    c.JSON(http.StatusOK, transfers)
+	c.JSON(http.StatusOK, transfers)
 }
 
 // @Summary Cancelar uma transferência em andamento
@@ -173,40 +181,40 @@ func ListTransfers(c *gin.Context) {
 // @Failure 400 {object} models.TransferResponse "Transferência já concluída"
 // @Router /api/v1/transfer/{requestId}/cancel [post]
 func CancelTransfer(c *gin.Context) {
-    requestID := c.Param("requestId")
+	requestID := c.Param("requestId")
 
-    statusMutex.Lock()
-    defer statusMutex.Unlock()
+	statusMutex.Lock()
+	defer statusMutex.Unlock()
 
-    status, exists := transferStatuses[requestID]
-    if !exists {
-        c.JSON(http.StatusNotFound, models.TransferResponse{
-            Status: "failed",
-            Error:  "Transferência não encontrada",
-        })
-        return
-    }
+	status, exists := transferStatuses[requestID]
+	if !exists {
+		c.JSON(http.StatusNotFound, models.TransferResponse{
+			Status: transfer.StatusFailed,
+			Error:  "Transferência não encontrada",
+		})
+		return
+	}
 
-    if status.Status != "in_progress" {
-        c.JSON(http.StatusBadRequest, models.TransferResponse{
-            Status:    "failed",
-            Error:     "Transferência já concluída ou falhou",
-            RequestID: requestID,
-        })
-        return
-    }
+	if status.Status != transfer.StatusInProgress {
+		c.JSON(http.StatusBadRequest, models.TransferResponse{
+			Status:    transfer.StatusFailed,
+			Error:     "Transferência já concluída ou falhou",
+			RequestID: requestID,
+		})
+		return
+	}
 
-    transferMgr, exists := transferManagers[requestID]
-    if exists {
-        transferMgr.Stop()
-        status.Status = "cancelled"
-        status.EndTime = time.Now().UTC().Format(time.RFC3339)
-        transferStatuses[requestID] = status
-        delete(transferManagers, requestID)
-    }
+	transferMgr, exists := transferManagers[requestID]
+	if exists {
+		transferMgr.Stop()
+		status.Status = transfer.StatusCancelled
+		status.EndTime = time.Now().UTC().Format(time.RFC3339)
+		transferStatuses[requestID] = status
+		delete(transferManagers, requestID)
+	}
 
-    c.JSON(http.StatusOK, models.TransferResponse{
-        Status:    "cancelled",
-        RequestID: requestID,
-    })
+	c.JSON(http.StatusOK, models.TransferResponse{
+		Status:    transfer.StatusCancelled,
+		RequestID: requestID,
+	})
 }

--- a/internal/mqutils/mqutils.go
+++ b/internal/mqutils/mqutils.go
@@ -3,211 +3,212 @@
 package mqutils
 
 import (
-    "fmt"
+	"fmt"
 
-    "github.com/ibm-messaging/mq-golang/v5/ibmmq"
+	"github.com/ibm-messaging/mq-golang/v5/ibmmq"
 )
 
 // MQConnectionConfig contém os parâmetros de conexão para um Queue Manager MQ
 type MQConnectionConfig struct {
-    QueueManagerName    string
-    ConnectionName      string
-    Channel             string
-    Username            string
-    Password            string
-    NonSharedConnection bool
+	QueueManagerName    string
+	ConnectionName      string
+	Channel             string
+	Username            string
+	Password            string
+	NonSharedConnection bool
 }
 
 // MQConnection encapsula uma conexão com um Queue Manager MQ
 type MQConnection struct {
-    QMgr        ibmmq.MQQueueManager
-    Config      MQConnectionConfig
-    IsConnected bool
+	QMgr        ibmmq.MQQueueManager
+	Config      MQConnectionConfig
+	IsConnected bool
 }
 
 // NewMQConnection cria uma nova instância de MQConnection
 func NewMQConnection(config MQConnectionConfig) *MQConnection {
-    return &MQConnection{
-        Config:      config,
-        IsConnected: false,
-    }
+	return &MQConnection{
+		Config:      config,
+		IsConnected: false,
+	}
 }
 
 // Connect estabelece uma conexão com o Queue Manager MQ
 func (conn *MQConnection) Connect() error {
-    cd := ibmmq.NewMQCD()
-    cd.ChannelName = conn.Config.Channel
-    cd.ConnectionName = conn.Config.ConnectionName
+	cd := ibmmq.NewMQCD()
+	cd.ChannelName = conn.Config.Channel
+	cd.ConnectionName = conn.Config.ConnectionName
 
-    cno := ibmmq.NewMQCNO()
-    cno.ClientConn = cd
+	cno := ibmmq.NewMQCNO()
+	cno.ClientConn = cd
 
-    if conn.Config.Username != "" {
-        csp := ibmmq.NewMQCSP()
-        csp.UserId = conn.Config.Username
-        csp.Password = conn.Config.Password
-        cno.SecurityParms = csp
-    }
+	if conn.Config.Username != "" {
+		csp := ibmmq.NewMQCSP()
+		csp.UserId = conn.Config.Username
+		csp.Password = conn.Config.Password
+		cno.SecurityParms = csp
+	}
 
-    var err error
-    conn.QMgr, err = ibmmq.Connx(conn.Config.QueueManagerName, cno)
-    if err != nil {
-        return fmt.Errorf("falha ao conectar ao Queue Manager %s: %v", conn.Config.QueueManagerName, err)
-    }
+	var err error
+	conn.QMgr, err = ibmmq.Connx(conn.Config.QueueManagerName, cno)
+	if err != nil {
+		return fmt.Errorf("falha ao conectar ao Queue Manager %s: %v", conn.Config.QueueManagerName, err)
+	}
 
-    conn.IsConnected = true
-    return nil
+	conn.IsConnected = true
+	return nil
 }
 
 // Disconnect fecha a conexão com o Queue Manager MQ
 func (conn *MQConnection) Disconnect() error {
-    if !conn.IsConnected {
-        return nil
-    }
+	if !conn.IsConnected {
+		return nil
+	}
 
-    err := conn.QMgr.Disc()
-    if err != nil {
-        return fmt.Errorf("falha ao desconectar do Queue Manager: %v", err)
-    }
+	err := conn.QMgr.Disc()
+	if err != nil {
+		return fmt.Errorf("falha ao desconectar do Queue Manager: %v", err)
+	}
 
-    conn.IsConnected = false
-    return nil
+	conn.IsConnected = false
+	return nil
 }
 
 // OpenQueue abre uma fila MQ para leitura ou escrita
 func (conn *MQConnection) OpenQueue(queueName string, forInput bool, nonShared bool) (ibmmq.MQObject, error) {
-    if !conn.IsConnected {
-        return ibmmq.MQObject{}, fmt.Errorf("não conectado ao Queue Manager")
-    }
+	if !conn.IsConnected {
+		return ibmmq.MQObject{}, fmt.Errorf("não conectado ao Queue Manager")
+	}
 
-    var openOptions int32
-    if forInput {
-        openOptions = ibmmq.MQOO_INPUT_SHARED | ibmmq.MQOO_FAIL_IF_QUIESCING | ibmmq.MQOO_SAVE_ALL_CONTEXT
-        if nonShared {
-            openOptions = ibmmq.MQOO_INPUT_EXCLUSIVE | ibmmq.MQOO_FAIL_IF_QUIESCING | ibmmq.MQOO_SAVE_ALL_CONTEXT
-        }
-    } else {
-        // Para manter todos os campos do MQMD, use apenas MQOO_SET_ALL_CONTEXT
-        openOptions = ibmmq.MQOO_OUTPUT | ibmmq.MQOO_FAIL_IF_QUIESCING | ibmmq.MQOO_SET_ALL_CONTEXT
-    }
+	var openOptions int32
+	if forInput {
+		openOptions = ibmmq.MQOO_INPUT_SHARED | ibmmq.MQOO_FAIL_IF_QUIESCING | ibmmq.MQOO_SAVE_ALL_CONTEXT
+		if nonShared {
+			openOptions = ibmmq.MQOO_INPUT_EXCLUSIVE | ibmmq.MQOO_FAIL_IF_QUIESCING | ibmmq.MQOO_SAVE_ALL_CONTEXT
+		}
+	} else {
+		// Para manter todos os campos do MQMD, use apenas MQOO_SET_ALL_CONTEXT
+		openOptions = ibmmq.MQOO_OUTPUT | ibmmq.MQOO_FAIL_IF_QUIESCING | ibmmq.MQOO_SET_ALL_CONTEXT
+	}
 
-    od := ibmmq.NewMQOD()
-    od.ObjectName = queueName
-    od.ObjectType = ibmmq.MQOT_Q
+	od := ibmmq.NewMQOD()
+	od.ObjectName = queueName
+	od.ObjectType = ibmmq.MQOT_Q
 
-    queue, err := conn.QMgr.Open(od, openOptions)
-    if err != nil {
-        return ibmmq.MQObject{}, fmt.Errorf("falha ao abrir a fila %s: %v", queueName, err)
-    }
+	queue, err := conn.QMgr.Open(od, openOptions)
+	if err != nil {
+		return ibmmq.MQObject{}, fmt.Errorf("falha ao abrir a fila %s: %v", queueName, err)
+	}
 
-    return queue, nil
+	return queue, nil
 }
 
 // CloseQueue fecha uma fila MQ
 func (conn *MQConnection) CloseQueue(queue ibmmq.MQObject) error {
-    err := queue.Close(0)
-    if err != nil {
-        return fmt.Errorf("falha ao fechar a fila: %v", err)
-    }
-    return nil
+	err := queue.Close(0)
+	if err != nil {
+		return fmt.Errorf("falha ao fechar a fila: %v", err)
+	}
+	return nil
 }
 
-// GetMessage obtém uma mensagem de uma fila MQ
-func (conn *MQConnection) GetMessage(queue ibmmq.MQObject, bufferSize int, waitInterval int) ([]byte, *ibmmq.MQMD, error) {
-    md := ibmmq.NewMQMD()
+// GetMessage obtém uma mensagem de uma fila MQ.
+// commitInterval controla se a operação é realizada dentro de uma unidade de trabalho.
+func (conn *MQConnection) GetMessage(queue ibmmq.MQObject, bufferSize int, commitInterval int) ([]byte, *ibmmq.MQMD, error) {
+	md := ibmmq.NewMQMD()
 
-    gmo := ibmmq.NewMQGMO()
-    gmo.Options = ibmmq.MQGMO_WAIT | ibmmq.MQGMO_FAIL_IF_QUIESCING
-    if waitInterval > 0 {
-        gmo.Options |= ibmmq.MQGMO_SYNCPOINT
-    } else {
-        gmo.Options |= ibmmq.MQGMO_NO_SYNCPOINT
-    }
-    gmo.WaitInterval = 5 * 1000
+	gmo := ibmmq.NewMQGMO()
+	gmo.Options = ibmmq.MQGMO_WAIT | ibmmq.MQGMO_FAIL_IF_QUIESCING
+	if commitInterval > 0 {
+		gmo.Options |= ibmmq.MQGMO_SYNCPOINT
+	} else {
+		gmo.Options |= ibmmq.MQGMO_NO_SYNCPOINT
+	}
+	gmo.WaitInterval = 5 * 1000
 
-    buffer := make([]byte, bufferSize)
+	buffer := make([]byte, bufferSize)
 
-    datalen, err := queue.Get(md, gmo, buffer)
-    if err != nil {
-        mqrc := err.(*ibmmq.MQReturn).MQRC
-        if mqrc == ibmmq.MQRC_NO_MSG_AVAILABLE {
-            return nil, nil, nil
-        }
-        return nil, nil, fmt.Errorf("falha ao obter mensagem: %v", err)
-    }
+	datalen, err := queue.Get(md, gmo, buffer)
+	if err != nil {
+		mqrc := err.(*ibmmq.MQReturn).MQRC
+		if mqrc == ibmmq.MQRC_NO_MSG_AVAILABLE {
+			return nil, nil, nil
+		}
+		return nil, nil, fmt.Errorf("falha ao obter mensagem: %v", err)
+	}
 
-    return buffer[:datalen], md, nil
+	return buffer[:datalen], md, nil
 }
 
 // PutMessage coloca uma mensagem em uma fila MQ, preservando o contexto da mensagem original
 // contextType: "pass" para MQPMO_PASS_ALL_CONTEXT, "set" para MQPMO_SET_ALL_CONTEXT, "none" para MQPMO_NO_CONTEXT
 func (conn *MQConnection) PutMessage(queue ibmmq.MQObject, data []byte, md *ibmmq.MQMD, commitInterval int, contextType string) error {
-    pmo := ibmmq.NewMQPMO()
-    if commitInterval > 0 {
-        pmo.Options |= ibmmq.MQPMO_SYNCPOINT
-    } else {
-        pmo.Options |= ibmmq.MQPMO_NO_SYNCPOINT
-    }
+	pmo := ibmmq.NewMQPMO()
+	if commitInterval > 0 {
+		pmo.Options |= ibmmq.MQPMO_SYNCPOINT
+	} else {
+		pmo.Options |= ibmmq.MQPMO_NO_SYNCPOINT
+	}
 
-    switch contextType {
-    case "pass":
-        pmo.Options |= ibmmq.MQPMO_PASS_ALL_CONTEXT
-    case "set":
-        pmo.Options |= ibmmq.MQPMO_SET_ALL_CONTEXT
-    default:
-        pmo.Options |= ibmmq.MQPMO_NO_CONTEXT
-    }
+	switch contextType {
+	case "pass":
+		pmo.Options |= ibmmq.MQPMO_PASS_ALL_CONTEXT
+	case "set":
+		pmo.Options |= ibmmq.MQPMO_SET_ALL_CONTEXT
+	default:
+		pmo.Options |= ibmmq.MQPMO_NO_CONTEXT
+	}
 
-    err := queue.Put(md, pmo, data)
-    if err != nil {
-        return fmt.Errorf("falha ao colocar mensagem: %v", err)
-    }
+	err := queue.Put(md, pmo, data)
+	if err != nil {
+		return fmt.Errorf("falha ao colocar mensagem: %v", err)
+	}
 
-    return nil
+	return nil
 }
 
 // Commit realiza um commit da transação atual
 func (conn *MQConnection) Commit() error {
-    if !conn.IsConnected {
-        return fmt.Errorf("não conectado ao Queue Manager")
-    }
+	if !conn.IsConnected {
+		return fmt.Errorf("não conectado ao Queue Manager")
+	}
 
-    err := conn.QMgr.Cmit()
-    if err != nil {
-        return fmt.Errorf("falha ao realizar commit: %v", err)
-    }
+	err := conn.QMgr.Cmit()
+	if err != nil {
+		return fmt.Errorf("falha ao realizar commit: %v", err)
+	}
 
-    return nil
+	return nil
 }
 
 // Backout realiza um backout da transação atual
 func (conn *MQConnection) Backout() error {
-    if !conn.IsConnected {
-        return fmt.Errorf("não conectado ao Queue Manager")
-    }
+	if !conn.IsConnected {
+		return fmt.Errorf("não conectado ao Queue Manager")
+	}
 
-    err := conn.QMgr.Back()
-    if err != nil {
-        return fmt.Errorf("falha ao realizar backout: %v", err)
-    }
+	err := conn.QMgr.Back()
+	if err != nil {
+		return fmt.Errorf("falha ao realizar backout: %v", err)
+	}
 
-    return nil
+	return nil
 }
 
 // NewCleanMQMD cria um novo MQMD limpo, copiando apenas campos essenciais de outro MQMD
 func NewCleanMQMD(src *ibmmq.MQMD) *ibmmq.MQMD {
-    if src == nil {
-        return ibmmq.NewMQMD()
-    }
-    md := ibmmq.NewMQMD()
-    md.Format = src.Format
-    md.Priority = src.Priority
-    md.Persistence = src.Persistence
-    md.CorrelId = src.CorrelId
-    md.MsgId = src.MsgId
-    md.UserIdentifier = src.UserIdentifier
-    md.PutApplName = src.PutApplName
-    md.PutDate = src.PutDate
-    md.PutTime = src.PutTime
-    return md
+	if src == nil {
+		return ibmmq.NewMQMD()
+	}
+	md := ibmmq.NewMQMD()
+	md.Format = src.Format
+	md.Priority = src.Priority
+	md.Persistence = src.Persistence
+	md.CorrelId = src.CorrelId
+	md.MsgId = src.MsgId
+	md.UserIdentifier = src.UserIdentifier
+	md.PutApplName = src.PutApplName
+	md.PutDate = src.PutDate
+	md.PutTime = src.PutTime
+	return md
 }

--- a/internal/mqutils/mqutils_stub.go
+++ b/internal/mqutils/mqutils_stub.go
@@ -43,7 +43,7 @@ func (c *MQConnection) OpenQueue(queueName string, forInput bool, nonShared bool
 
 func (c *MQConnection) CloseQueue(queue struct{}) error { return nil }
 
-func (c *MQConnection) GetMessage(queue struct{}, bufferSize int, waitInterval int) ([]byte, interface{}, error) {
+func (c *MQConnection) GetMessage(queue struct{}, bufferSize int, commitInterval int) ([]byte, interface{}, error) {
 	return nil, nil, nil
 }
 

--- a/internal/transfer/transfer.go
+++ b/internal/transfer/transfer.go
@@ -1,177 +1,186 @@
 package transfer
 
 import (
-    "context"
-    "sync"
-    "time"
+	"context"
+	"sync"
+	"time"
 
-    "mq-transfer-go/internal/mqutils"
-    "mq-transfer-go/internal/otelutils"
+	"mq-transfer-go/internal/mqutils"
+	"mq-transfer-go/internal/otelutils"
+)
+
+// Predefined transfer statuses to avoid typos and allow consistent checks.
+const (
+	StatusPending    = "pending"
+	StatusInProgress = "in_progress"
+	StatusCancelled  = "cancelled"
+	StatusCompleted  = "completed"
+	StatusFailed     = "failed"
 )
 
 // TransferOptions defines parameters for a transfer operation.
 type TransferOptions struct {
-    SourceConfig        mqutils.MQConnectionConfig
-    SourceQueue         string
-    DestConfig          mqutils.MQConnectionConfig
-    DestQueue           string
-    BufferSize          int
-    CommitInterval      int
-    NonSharedConnection bool
+	SourceConfig        mqutils.MQConnectionConfig
+	SourceQueue         string
+	DestConfig          mqutils.MQConnectionConfig
+	DestQueue           string
+	BufferSize          int
+	CommitInterval      int
+	NonSharedConnection bool
 }
 
 // Stats holds runtime statistics of a transfer.
 type Stats struct {
-    MessagesTransferred int64
-    BytesTransferred    int64
-    Status              string
-    EndTime             time.Time
-    Error               string
+	MessagesTransferred int64
+	BytesTransferred    int64
+	Status              string
+	EndTime             time.Time
+	Error               string
 }
 
 // TransferManager performs message transfer. This is a minimal stub
 // implementation to allow the application to compile and run tests.
 type TransferManager struct {
-    opts  TransferOptions
-    mu    sync.RWMutex
-    stats Stats
-    quit  chan struct{}
-    done  chan struct{}
+	opts  TransferOptions
+	mu    sync.RWMutex
+	stats Stats
+	quit  chan struct{}
+	done  chan struct{}
 }
 
 // NewTransferManager creates a new manager with the given options.
 func NewTransferManager(opts TransferOptions) *TransferManager {
-    return &TransferManager{opts: opts, stats: Stats{Status: "pending"}, quit: make(chan struct{}), done: make(chan struct{})}
+	return &TransferManager{opts: opts, stats: Stats{Status: StatusPending}, quit: make(chan struct{}), done: make(chan struct{})}
 }
 
 // Start begins the transfer asynchronously.
 func (tm *TransferManager) Start() {
-    go tm.run()
+	go tm.run()
 }
 
 func (tm *TransferManager) run() {
-    tm.mu.Lock()
-    tm.stats.Status = "in_progress"
-    tm.mu.Unlock()
-    defer close(tm.done)
+	tm.mu.Lock()
+	tm.stats.Status = StatusInProgress
+	tm.mu.Unlock()
+	defer close(tm.done)
 
-    metrics := otelutils.GetMetrics()
-    ctx := context.Background()
+	metrics := otelutils.GetMetrics()
+	ctx := context.Background()
 
-    srcConn := mqutils.NewMQConnection(tm.opts.SourceConfig)
-    if err := srcConn.Connect(); err != nil {
-        tm.finishWithError("failed", err)
-        return
-    }
-    defer srcConn.Disconnect()
+	srcConn := mqutils.NewMQConnection(tm.opts.SourceConfig)
+	if err := srcConn.Connect(); err != nil {
+		tm.finishWithError(StatusFailed, err)
+		return
+	}
+	defer srcConn.Disconnect()
 
-    destConn := mqutils.NewMQConnection(tm.opts.DestConfig)
-    if err := destConn.Connect(); err != nil {
-        tm.finishWithError("failed", err)
-        return
-    }
-    defer destConn.Disconnect()
+	destConn := mqutils.NewMQConnection(tm.opts.DestConfig)
+	if err := destConn.Connect(); err != nil {
+		tm.finishWithError(StatusFailed, err)
+		return
+	}
+	defer destConn.Disconnect()
 
-    destQ, err := destConn.OpenQueue(tm.opts.DestQueue, false, false)
-    if err != nil {
-        tm.finishWithError("failed", err)
-        return
-    }
-    defer destConn.CloseQueue(destQ)
+	destQ, err := destConn.OpenQueue(tm.opts.DestQueue, false, false)
+	if err != nil {
+		tm.finishWithError(StatusFailed, err)
+		return
+	}
+	defer destConn.CloseQueue(destQ)
 
-    srcQ, err := srcConn.OpenQueue(tm.opts.SourceQueue, true, tm.opts.NonSharedConnection)
-    if err != nil {
-        tm.finishWithError("failed", err)
-        return
-    }
-    defer srcConn.CloseQueue(srcQ)
+	srcQ, err := srcConn.OpenQueue(tm.opts.SourceQueue, true, tm.opts.NonSharedConnection)
+	if err != nil {
+		tm.finishWithError(StatusFailed, err)
+		return
+	}
+	defer srcConn.CloseQueue(srcQ)
 
-    commitCounter := 0
-    for {
-        select {
-        case <-tm.quit:
-            tm.mu.Lock()
-            tm.stats.Status = "cancelled"
-            tm.stats.EndTime = time.Now()
-            tm.mu.Unlock()
-            return
-        default:
-            start := time.Now()
-            data, md, err := srcConn.GetMessage(srcQ, tm.opts.BufferSize, tm.opts.CommitInterval)
-            if err != nil {
-                tm.finishWithError("failed", err)
-                return
-            }
-            if data == nil {
-                tm.mu.Lock()
-                tm.stats.Status = "completed"
-                tm.stats.EndTime = time.Now()
-                tm.mu.Unlock()
-                return
-            }
+	commitCounter := 0
+	for {
+		select {
+		case <-tm.quit:
+			tm.mu.Lock()
+			tm.stats.Status = StatusCancelled
+			tm.stats.EndTime = time.Now()
+			tm.mu.Unlock()
+			return
+		default:
+			start := time.Now()
+			data, md, err := srcConn.GetMessage(srcQ, tm.opts.BufferSize, tm.opts.CommitInterval)
+			if err != nil {
+				tm.finishWithError(StatusFailed, err)
+				return
+			}
+			if data == nil {
+				tm.mu.Lock()
+				tm.stats.Status = StatusCompleted
+				tm.stats.EndTime = time.Now()
+				tm.mu.Unlock()
+				return
+			}
 
-            if err := destConn.PutMessage(destQ, data, md, tm.opts.CommitInterval, "set"); err != nil {
-                if tm.opts.CommitInterval > 0 {
-                    // rollback the GET on error to avoid message loss
-                    _ = srcConn.Backout()
-                    _ = destConn.Backout()
-                }
-                tm.finishWithError("failed", err)
-                return
-            }
+			if err := destConn.PutMessage(destQ, data, md, tm.opts.CommitInterval, "set"); err != nil {
+				if tm.opts.CommitInterval > 0 {
+					// rollback the GET on error to avoid message loss
+					_ = srcConn.Backout()
+					_ = destConn.Backout()
+				}
+				tm.finishWithError(StatusFailed, err)
+				return
+			}
 
-            tm.mu.Lock()
-            tm.stats.MessagesTransferred++
-            tm.stats.BytesTransferred += int64(len(data))
-            tm.mu.Unlock()
+			tm.mu.Lock()
+			tm.stats.MessagesTransferred++
+			tm.stats.BytesTransferred += int64(len(data))
+			tm.mu.Unlock()
 
-            if metrics != nil {
-                metrics.MessagesTransferred.Add(ctx, 1)
-                metrics.BytesTransferred.Add(ctx, int64(len(data)))
-                metrics.TransferDuration.Record(ctx, float64(time.Since(start).Milliseconds()))
-            }
+			if metrics != nil {
+				metrics.MessagesTransferred.Add(ctx, 1)
+				metrics.BytesTransferred.Add(ctx, int64(len(data)))
+				metrics.TransferDuration.Record(ctx, float64(time.Since(start).Milliseconds()))
+			}
 
-            if tm.opts.CommitInterval > 0 {
-                commitCounter++
-                if commitCounter >= tm.opts.CommitInterval {
-                    // commit destination first so source is not lost on failure
-                    if err := destConn.Commit(); err != nil {
-                        if backErr := srcConn.Backout(); backErr != nil {
-                            _ = backErr
-                        }
-                        tm.finishWithError("failed", err)
-                        return
-                    }
-                    if err := srcConn.Commit(); err != nil {
-                        tm.finishWithError("failed", err)
-                        return
-                    }
-                    commitCounter = 0
-                    if metrics != nil {
-                        metrics.CommitCounter.Add(ctx, 1)
-                    }
-                }
-            }
-        }
-    }
+			if tm.opts.CommitInterval > 0 {
+				commitCounter++
+				if commitCounter >= tm.opts.CommitInterval {
+					// commit destination first so source is not lost on failure
+					if err := destConn.Commit(); err != nil {
+						if backErr := srcConn.Backout(); backErr != nil {
+							_ = backErr
+						}
+						tm.finishWithError(StatusFailed, err)
+						return
+					}
+					if err := srcConn.Commit(); err != nil {
+						tm.finishWithError(StatusFailed, err)
+						return
+					}
+					commitCounter = 0
+					if metrics != nil {
+						metrics.CommitCounter.Add(ctx, 1)
+					}
+				}
+			}
+		}
+	}
 }
 
 func (tm *TransferManager) finishWithError(status string, err error) {
-    tm.mu.Lock()
-    tm.stats.Status = status
-    tm.stats.Error = err.Error()
-    tm.stats.EndTime = time.Now()
-    tm.mu.Unlock()
+	tm.mu.Lock()
+	tm.stats.Status = status
+	tm.stats.Error = err.Error()
+	tm.stats.EndTime = time.Now()
+	tm.mu.Unlock()
 }
 
 // Stop cancels the transfer.
 func (tm *TransferManager) Stop() {
-    close(tm.quit)
+	close(tm.quit)
 }
 
 // GetStats returns a snapshot of the current stats.
 func (tm *TransferManager) GetStats() Stats {
-    tm.mu.RLock()
-    defer tm.mu.RUnlock()
-    return tm.stats
+	tm.mu.RLock()
+	defer tm.mu.RUnlock()
+	return tm.stats
 }

--- a/internal/transfer/transfer_test.go
+++ b/internal/transfer/transfer_test.go
@@ -1,0 +1,14 @@
+package transfer
+
+import "testing"
+
+func TestTransferCancel(t *testing.T) {
+	tm := NewTransferManager(TransferOptions{})
+	tm.Start()
+	tm.Stop()
+	<-tm.done
+	stats := tm.GetStats()
+	if stats.Status != StatusCancelled {
+		t.Fatalf("expected %s, got %s", StatusCancelled, stats.Status)
+	}
+}


### PR DESCRIPTION
## Summary
- centralize transfer status strings as constants
- clean up transfer maps and remove status after a TTL
- rename GetMessage parameter to clarify commit usage
- support cancellation status in monitor loop
- add simple unit test for transfer cancellation

## Testing
- `go test ./...` *(fails: github.com/gabriel-vasile/mimetype@v1.4.3: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6841eea6b0408325bd6160a8c5e0e71f