### PR TITLE
Optimize MQ message transfer

### DIFF
--- a/internal/mqutils/mqutils.go
+++ b/internal/mqutils/mqutils.go
@@ -114,7 +114,7 @@ func (conn *MQConnection) CloseQueue(queue ibmmq.MQObject) error {
 
 // GetMessage obtém uma mensagem de uma fila MQ.
 // commitInterval controla se a operação é realizada dentro de uma unidade de trabalho.
-func (conn *MQConnection) GetMessage(queue ibmmq.MQObject, bufferSize int, commitInterval int) ([]byte, *ibmmq.MQMD, error) {
+func (conn *MQConnection) GetMessage(queue ibmmq.MQObject, buffer []byte, commitInterval int) ([]byte, *ibmmq.MQMD, error) {
 	md := ibmmq.NewMQMD()
 
 	gmo := ibmmq.NewMQGMO()
@@ -126,7 +126,9 @@ func (conn *MQConnection) GetMessage(queue ibmmq.MQObject, bufferSize int, commi
 	}
 	gmo.WaitInterval = 5 * 1000
 
-	buffer := make([]byte, bufferSize)
+	if len(buffer) == 0 {
+		buffer = make([]byte, 1024)
+	}
 
 	datalen, err := queue.Get(md, gmo, buffer)
 	if err != nil {

--- a/internal/mqutils/mqutils_stub.go
+++ b/internal/mqutils/mqutils_stub.go
@@ -43,8 +43,11 @@ func (c *MQConnection) OpenQueue(queueName string, forInput bool, nonShared bool
 
 func (c *MQConnection) CloseQueue(queue struct{}) error { return nil }
 
-func (c *MQConnection) GetMessage(queue struct{}, bufferSize int, commitInterval int) ([]byte, interface{}, error) {
-	return nil, nil, nil
+func (c *MQConnection) GetMessage(queue struct{}, buffer []byte, commitInterval int) ([]byte, interface{}, error) {
+	if len(buffer) == 0 {
+		buffer = make([]byte, 1)
+	}
+	return buffer[:0], nil, nil
 }
 
 func (c *MQConnection) PutMessage(queue struct{}, data []byte, md interface{}, commitInterval int, contextType string) error {


### PR DESCRIPTION
## Summary
- reuse buffer when retrieving messages from MQ
- expose buffer parameter in MQ utils
- integrate sync/atomic for stats counters

## Testing
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6841f2847d9c8325928174c77651e258