### PR TITLE
Fix incomplete transfers

### DIFF
--- a/internal/transfer/transfer.go
+++ b/internal/transfer/transfer.go
@@ -222,7 +222,10 @@ func (tm *TransferManager) run() {
 		go worker()
 	}
 
-	<-tm.quit
+	select {
+	case <-tm.quit:
+	case <-ctx.Done():
+	}
 	cancel()
 	wg.Wait()
 


### PR DESCRIPTION
## Summary
- ensure transfer run loop exits when context completes

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6841fec2e8e08325a04e7388734e24f1