### PR TITLE
Improve MQ transfer transaction safety

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -27,6 +27,8 @@ go run -tags ibmmq main.go
 
 - `ENV`: define o ambiente (padrão `development`)
 - `OTLP_ENDPOINT`: endpoint OTLP para exportação de métricas (opcional)
+- `WORKER_COUNT`: número de goroutines para processamento paralelo (opcional)
+- `BATCH_SIZE`: tamanho do lote de mensagens por commit (padrão 10)
 
 ## Uso da API
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,12 @@ Retorna o status de saúde da aplicação.
 
 - **bufferSize**: tamanho do buffer para operação `MQGET` (padrão 1MB).
 - **nonSharedConnection**: abre a fila de origem em modo exclusivo quando `true`.
-- **commitInterval**: define o número de mensagens processadas antes do commit. Valor 0 desativa transações.
+- **commitInterval**: define o número de mensagens processadas antes do commit. Caso omisso, o valor padrão de 10 é utilizado.
+
+### Variáveis de Ambiente
+
+- **WORKER_COUNT**: define o número de goroutines para processar mensagens em paralelo. Quando não informado, utiliza o número de CPUs.
+- **BATCH_SIZE**: tamanho do lote de mensagens antes do commit quando `commitInterval` não é especificado na requisição.
 
 ### Métricas OpenTelemetry
 

--- a/internal/mqutils/mqutils_stub.go
+++ b/internal/mqutils/mqutils_stub.go
@@ -43,14 +43,14 @@ func (c *MQConnection) OpenQueue(queueName string, forInput bool, nonShared bool
 
 func (c *MQConnection) CloseQueue(queue struct{}) error { return nil }
 
-func (c *MQConnection) GetMessage(queue struct{}, buffer []byte, commitInterval int) ([]byte, interface{}, error) {
+func (c *MQConnection) GetMessage(queue struct{}, buffer []byte) ([]byte, interface{}, error) {
 	if len(buffer) == 0 {
 		buffer = make([]byte, 1)
 	}
 	return buffer[:0], nil, nil
 }
 
-func (c *MQConnection) PutMessage(queue struct{}, data []byte, md interface{}, commitInterval int, contextType string) error {
+func (c *MQConnection) PutMessage(queue struct{}, data []byte, md interface{}, contextType string) error {
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- allow configuring worker count and commit interval through env vars
- default commit interval to 10 messages
- update transfer logic to always use MQ syncpoints
- document new environment variables

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684200a846ac8325ab1ca26d87ebd92a