### PR TITLE
Fix message loss in transfer

### DIFF
--- a/internal/transfer/transfer.go
+++ b/internal/transfer/transfer.go
@@ -146,7 +146,6 @@ func (tm *TransferManager) run() {
 					tm.stats.EndTime = time.Now()
 					tm.mu.Unlock()
 					close(msgCh)
-					cancel()
 					return
 				}
 


### PR DESCRIPTION
## Summary
- prevent premature cancellation after reading all messages

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684202e0f5b48325b7ecebd97fae8231