### PR TITLE
Fix uncommitted messages on completion

### DIFF
--- a/internal/transfer/transfer.go
+++ b/internal/transfer/transfer.go
@@ -146,6 +146,7 @@ func (tm *TransferManager) run() {
 					tm.stats.EndTime = time.Now()
 					tm.mu.Unlock()
 					close(msgCh)
+					cancel()
 					return
 				}
 
@@ -177,6 +178,7 @@ func (tm *TransferManager) run() {
 						_ = destConn.Backout()
 						tm.destMu.Unlock()
 						tm.srcMu.Unlock()
+						atomic.StoreInt32(&tm.commitCounter, 0)
 					}
 					tm.finishWithError(StatusFailed, err)
 					cancel()
@@ -202,6 +204,7 @@ func (tm *TransferManager) run() {
 							}
 							tm.srcMu.Unlock()
 							tm.destMu.Unlock()
+							atomic.StoreInt32(&tm.commitCounter, 0)
 							tm.finishWithError(StatusFailed, err)
 							cancel()
 							return
@@ -209,6 +212,7 @@ func (tm *TransferManager) run() {
 						if err := srcConn.Commit(); err != nil {
 							tm.srcMu.Unlock()
 							tm.destMu.Unlock()
+							atomic.StoreInt32(&tm.commitCounter, 0)
 							tm.finishWithError(StatusFailed, err)
 							cancel()
 							return


### PR DESCRIPTION
## Summary
- ensure context is cancelled when source queue is exhausted
- reset commit counter when backing out or commit fails to avoid stale pending count

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684204bfa6948325873da60f2b80d73d