### PR TITLE
Add unit tests

### DIFF
--- a/api/docs/docs_test.go
+++ b/api/docs/docs_test.go
@@ -1,0 +1,13 @@
+package docs_test
+
+import (
+	"testing"
+
+	"mq-transfer-go/api/docs"
+)
+
+func TestDocsInit(t *testing.T) {
+	if docs.SwaggerInfo == nil {
+		t.Fatal("SwaggerInfo should not be nil")
+	}
+}

--- a/api/handlers/health_test.go
+++ b/api/handlers/health_test.go
@@ -1,0 +1,20 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestHealthCheck(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	HealthCheck(c)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}

--- a/api/handlers/transfer.go
+++ b/api/handlers/transfer.go
@@ -21,7 +21,12 @@ var (
 )
 
 // statusTTL defines how long finished transfer statuses are kept in memory.
-const statusTTL = 10 * time.Minute
+// It is a variable so tests can shorten the duration.
+var statusTTL = 10 * time.Minute
+
+// monitorInterval controls how often the monitor goroutine checks transfer
+// status. It is exported as a variable to allow tests to speed up execution.
+var monitorInterval = time.Second
 
 // @Summary Iniciar transferência de mensagens MQ
 // @Description Inicia uma transferência de mensagens de uma fila MQ para outra
@@ -123,7 +128,7 @@ func StartTransfer(c *gin.Context) {
 }
 
 func monitorTransfer(requestID string, transferMgr *transfer.TransferManager) {
-	ticker := time.NewTicker(1 * time.Second)
+	ticker := time.NewTicker(monitorInterval)
 	defer ticker.Stop()
 
 	for {

--- a/api/handlers/transfer_test.go
+++ b/api/handlers/transfer_test.go
@@ -1,0 +1,180 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"mq-transfer-go/api/models"
+	"mq-transfer-go/internal/transfer"
+)
+
+// helper to reset globals
+func resetGlobals() {
+	statusMutex.Lock()
+	transferStatuses = make(map[string]models.TransferStatus)
+	transferManagers = make(map[string]*transfer.TransferManager)
+	statusMutex.Unlock()
+	monitorInterval = time.Millisecond
+	statusTTL = time.Millisecond
+}
+
+func TestStartTransferInvalid(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	resetGlobals()
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString("{"))
+
+	StartTransfer(c)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestTransferHandlersFlow(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	resetGlobals()
+	req := models.TransferRequest{
+		Source:           models.ConnectionDetails{QueueManagerName: "qm1", ConnectionName: "c", Channel: "ch"},
+		SourceQueue:      "SQ",
+		Destination:      models.ConnectionDetails{QueueManagerName: "qm2", ConnectionName: "c", Channel: "ch"},
+		DestinationQueue: "DQ",
+		CommitInterval:   1,
+	}
+	body, _ := json.Marshal(req)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/transfer", bytes.NewBuffer(body))
+	StartTransfer(c)
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d", w.Code)
+	}
+	var resp models.TransferResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode err: %v", err)
+	}
+	id := resp.RequestID
+
+	// check status exists
+	w2 := httptest.NewRecorder()
+	c2, _ := gin.CreateTestContext(w2)
+	c2.Params = gin.Params{gin.Param{Key: "requestId", Value: id}}
+	GetTransferStatus(c2)
+	if w2.Code != http.StatusOK {
+		t.Fatalf("status not found")
+	}
+
+	// cancel transfer
+	w3 := httptest.NewRecorder()
+	c3, _ := gin.CreateTestContext(w3)
+	c3.Params = gin.Params{gin.Param{Key: "requestId", Value: id}}
+	CancelTransfer(c3)
+	if w3.Code != http.StatusOK {
+		t.Fatalf("cancel failed: %d", w3.Code)
+	}
+
+	// list transfers (should have one or zero)
+	time.Sleep(2 * time.Millisecond)
+	w4 := httptest.NewRecorder()
+	c4, _ := gin.CreateTestContext(w4)
+	ListTransfers(c4)
+	if w4.Code != http.StatusOK {
+		t.Fatalf("list failed")
+	}
+}
+
+func TestCancelNotFound(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	resetGlobals()
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Params = gin.Params{gin.Param{Key: "requestId", Value: "na"}}
+	CancelTransfer(c)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestCancelCompleted(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	resetGlobals()
+	id := "id1"
+	statusMutex.Lock()
+	transferStatuses[id] = models.TransferStatus{RequestID: id, Status: transfer.StatusCompleted}
+	statusMutex.Unlock()
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Params = gin.Params{gin.Param{Key: "requestId", Value: id}}
+	CancelTransfer(c)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestGetStatusNotFound(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	resetGlobals()
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Params = gin.Params{gin.Param{Key: "requestId", Value: "none"}}
+	GetTransferStatus(c)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404")
+	}
+}
+
+func TestStartTransferWithEnv(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	resetGlobals()
+	t.Setenv("BUFFER_SIZE", "2")
+	t.Setenv("WORKER_COUNT", "1")
+	t.Setenv("BATCH_SIZE", "1")
+	req := models.TransferRequest{
+		Source:           models.ConnectionDetails{QueueManagerName: "qm1", ConnectionName: "c", Channel: "ch"},
+		SourceQueue:      "SQ",
+		Destination:      models.ConnectionDetails{QueueManagerName: "qm2", ConnectionName: "c", Channel: "ch"},
+		DestinationQueue: "DQ",
+	}
+	body, _ := json.Marshal(req)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/transfer", bytes.NewBuffer(body))
+	StartTransfer(c)
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d", w.Code)
+	}
+	var resp models.TransferResponse
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	// cleanup
+	w2 := httptest.NewRecorder()
+	c2, _ := gin.CreateTestContext(w2)
+	c2.Params = gin.Params{gin.Param{Key: "requestId", Value: resp.RequestID}}
+	CancelTransfer(c2)
+}
+
+func TestMonitorTransferCompleted(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	resetGlobals()
+	id := "mid"
+	tm := transfer.NewTransferManager(transfer.TransferOptions{})
+	tm.SetStatsForTest(transfer.Stats{Status: transfer.StatusCompleted, EndTime: time.Now()})
+	statusMutex.Lock()
+	transferStatuses[id] = models.TransferStatus{RequestID: id}
+	transferManagers[id] = tm
+	statusMutex.Unlock()
+	go monitorTransfer(id, tm)
+	time.Sleep(3 * time.Millisecond)
+	statusMutex.RLock()
+	_, okMgr := transferManagers[id]
+	_, okStat := transferStatuses[id]
+	statusMutex.RUnlock()
+	if okMgr || okStat {
+		t.Fatalf("expected cleanup")
+	}
+}

--- a/internal/mqutils/mqutils_stub.go
+++ b/internal/mqutils/mqutils_stub.go
@@ -20,11 +20,20 @@ type MQConnection struct {
 	IsConnected bool
 }
 
+// Testing controls
+var (
+	ReturnNilMessage bool
+	FailConnect      bool
+)
+
 func NewMQConnection(config MQConnectionConfig) *MQConnection {
 	return &MQConnection{Config: config}
 }
 
 func (c *MQConnection) Connect() error {
+	if FailConnect {
+		return errors.New("connect fail")
+	}
 	c.IsConnected = true
 	return nil
 }
@@ -44,6 +53,9 @@ func (c *MQConnection) OpenQueue(queueName string, forInput bool, nonShared bool
 func (c *MQConnection) CloseQueue(queue struct{}) error { return nil }
 
 func (c *MQConnection) GetMessage(queue struct{}, buffer []byte) ([]byte, interface{}, error) {
+	if ReturnNilMessage {
+		return nil, nil, nil
+	}
 	if len(buffer) == 0 {
 		buffer = make([]byte, 1)
 	}

--- a/internal/mqutils/mqutils_test.go
+++ b/internal/mqutils/mqutils_test.go
@@ -1,0 +1,53 @@
+package mqutils
+
+import "testing"
+
+func TestMQConnectionLifecycle(t *testing.T) {
+	cfg := MQConnectionConfig{QueueManagerName: "QM", ConnectionName: "conn", Channel: "CH"}
+	c := NewMQConnection(cfg)
+	if err := c.Connect(); err != nil {
+		t.Fatalf("connect error: %v", err)
+	}
+	if !c.IsConnected {
+		t.Fatalf("expected connected")
+	}
+	if _, err := c.OpenQueue("Q", true, false); err != nil {
+		t.Fatalf("open queue error: %v", err)
+	}
+	if err := c.CloseQueue(struct{}{}); err != nil {
+		t.Fatalf("close queue error: %v", err)
+	}
+	if _, _, err := c.GetMessage(struct{}{}, nil); err != nil {
+		t.Fatalf("get message error: %v", err)
+	}
+	if err := c.PutMessage(struct{}{}, []byte("data"), nil, "none"); err != nil {
+		t.Fatalf("put message error: %v", err)
+	}
+	if err := c.Commit(); err != nil {
+		t.Fatalf("commit error: %v", err)
+	}
+	if err := c.Backout(); err != nil {
+		t.Fatalf("backout error: %v", err)
+	}
+	if err := c.Disconnect(); err != nil {
+		t.Fatalf("disconnect error: %v", err)
+	}
+	if c.IsConnected {
+		t.Fatalf("expected disconnected")
+	}
+}
+
+func TestMQConnectionFailures(t *testing.T) {
+	FailConnect = true
+	c := NewMQConnection(MQConnectionConfig{})
+	if err := c.Connect(); err == nil {
+		t.Fatalf("expected connect fail")
+	}
+	FailConnect = false
+	c.Connect()
+	ReturnNilMessage = true
+	if data, _, _ := c.GetMessage(struct{}{}, nil); data != nil {
+		t.Fatalf("expected nil data")
+	}
+	ReturnNilMessage = false
+}

--- a/internal/otelutils/otelutils_test.go
+++ b/internal/otelutils/otelutils_test.go
@@ -1,0 +1,27 @@
+package otelutils
+
+import (
+	"context"
+	"testing"
+)
+
+func TestInitOTelNoEndpoint(t *testing.T) {
+	metrics, err := InitOTel(OTelConfig{})
+	if err != nil || metrics != nil {
+		t.Fatalf("expected nil metrics and no error")
+	}
+	if GetMetrics() != nil {
+		t.Fatalf("expected GetMetrics nil")
+	}
+}
+
+func TestInitOTelWithEndpoint(t *testing.T) {
+	m, err := InitOTel(OTelConfig{ServiceName: "s", ServiceVersion: "1", Environment: "t", OTLPEndpoint: "localhost:4317"})
+	if err != nil || m == nil {
+		t.Fatalf("unexpected init failure: %v", err)
+	}
+	if GetMetrics() == nil {
+		t.Fatalf("metrics not set")
+	}
+	Shutdown(context.Background())
+}

--- a/internal/transfer/transfer.go
+++ b/internal/transfer/transfer.go
@@ -292,3 +292,11 @@ func (tm *TransferManager) GetStats() Stats {
 	stats.BytesTransferred = atomic.LoadInt64(&tm.stats.BytesTransferred)
 	return stats
 }
+
+// SetStatsForTest allows tests to set internal stats directly.
+// It has no effect on production usage.
+func (tm *TransferManager) SetStatsForTest(s Stats) {
+	tm.mu.Lock()
+	tm.stats = s
+	tm.mu.Unlock()
+}

--- a/internal/transfer/transfer_test.go
+++ b/internal/transfer/transfer_test.go
@@ -1,6 +1,15 @@
 package transfer
 
-import "testing"
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"mq-transfer-go/internal/mqutils"
+)
 
 func TestTransferCancel(t *testing.T) {
 	tm := NewTransferManager(TransferOptions{})
@@ -11,4 +20,47 @@ func TestTransferCancel(t *testing.T) {
 	if stats.Status != StatusCancelled {
 		t.Fatalf("expected %s, got %s", StatusCancelled, stats.Status)
 	}
+}
+
+func TestFinishWithError(t *testing.T) {
+	tm := NewTransferManager(TransferOptions{})
+	tm.finishWithError(StatusFailed, fmt.Errorf("fail"))
+	s := tm.GetStats()
+	if s.Status != StatusFailed || s.Error != "fail" {
+		t.Fatalf("unexpected stats: %+v", s)
+	}
+}
+
+func TestGetStatsCounters(t *testing.T) {
+	tm := NewTransferManager(TransferOptions{})
+	atomic.AddInt64(&tm.stats.MessagesTransferred, 5)
+	atomic.AddInt64(&tm.stats.BytesTransferred, 10)
+	s := tm.GetStats()
+	if s.MessagesTransferred != 5 || s.BytesTransferred != 10 {
+		t.Fatalf("unexpected counts: %+v", s)
+	}
+}
+
+func TestWorkerCancel(t *testing.T) {
+	tm := NewTransferManager(TransferOptions{CommitInterval: 1, BufferSize: 1})
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	ch := make(chan workerResult, 1)
+	wg.Add(1)
+	go tm.worker(ctx, cancel, &wg, ch, context.Background(), nil)
+	time.Sleep(2 * time.Millisecond)
+	cancel()
+	wg.Wait()
+}
+
+func TestWorkerIdleExit(t *testing.T) {
+	tm := NewTransferManager(TransferOptions{CommitInterval: 1, BufferSize: 1})
+	mqutils.ReturnNilMessage = true
+	defer func() { mqutils.ReturnNilMessage = false }()
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	ch := make(chan workerResult, 1)
+	wg.Add(1)
+	go tm.worker(ctx, cancel, &wg, ch, context.Background(), nil)
+	wg.Wait()
 }


### PR DESCRIPTION
## Summary
- switch several constants to vars for easier test control
- expose SetStatsForTest
- add testing knobs to stub MQ utils
- implement comprehensive unit tests

## Testing
- `go test ./api/handlers -run . -v`
- `go test ./api/docs -run . -v`
- `go test ./internal/mqutils -run . -v`
- `go test ./internal/otelutils -run . -v`
- `go test ./internal/transfer -run . -v`
- `go test ./... -coverprofile=coverage.out`

------
https://chatgpt.com/codex/tasks/task_e_687af56b016c83258a54a48261ef6365