### PR TITLE
Improve test coverage

### DIFF
--- a/internal/mqutils/mqutils_test.go
+++ b/internal/mqutils/mqutils_test.go
@@ -3,6 +3,7 @@ package mqutils
 import "testing"
 
 func TestMQConnectionLifecycle(t *testing.T) {
+	ResetTestState()
 	cfg := MQConnectionConfig{QueueManagerName: "QM", ConnectionName: "conn", Channel: "CH"}
 	c := NewMQConnection(cfg)
 	if err := c.Connect(); err != nil {
@@ -38,16 +39,52 @@ func TestMQConnectionLifecycle(t *testing.T) {
 }
 
 func TestMQConnectionFailures(t *testing.T) {
-	FailConnect = true
+	ResetTestState()
+	FailConnectCall = 1
 	c := NewMQConnection(MQConnectionConfig{})
 	if err := c.Connect(); err == nil {
 		t.Fatalf("expected connect fail")
 	}
-	FailConnect = false
-	c.Connect()
+	ResetTestState()
+	if err := c.Connect(); err != nil {
+		t.Fatalf("unexpected connect err: %v", err)
+	}
+	if _, err := c.OpenQueue("Q", true, false); err != nil {
+		t.Fatalf("open queue error: %v", err)
+	}
+	ResetTestState()
 	ReturnNilMessage = true
 	if data, _, _ := c.GetMessage(struct{}{}, nil); data != nil {
 		t.Fatalf("expected nil data")
 	}
-	ReturnNilMessage = false
+	ResetTestState()
+	FailPut = true
+	if err := c.PutMessage(struct{}{}, nil, nil, "none"); err == nil {
+		t.Fatalf("expected put fail")
+	}
+	ResetTestState()
+	FailCommit = true
+	if err := c.Commit(); err == nil {
+		t.Fatalf("expected commit fail")
+	}
+	ResetTestState()
+	FailGet = true
+	if _, _, err := c.GetMessage(struct{}{}, nil); err == nil {
+		t.Fatalf("expected get fail")
+	}
+}
+
+func TestOpenQueueNotConnected(t *testing.T) {
+	ResetTestState()
+	c := NewMQConnection(MQConnectionConfig{})
+	if _, err := c.OpenQueue("q", true, false); err == nil {
+		t.Fatalf("expected not connected")
+	}
+	ResetTestState()
+	FailOpenCall = 1
+	_ = c.Connect()
+	if _, err := c.OpenQueue("q", true, false); err == nil {
+		t.Fatalf("expected open fail")
+	}
+	ResetTestState()
 }

--- a/internal/otelutils/otelutils.go
+++ b/internal/otelutils/otelutils.go
@@ -32,6 +32,17 @@ type OTelConfig struct {
 	OTLPEndpoint   string
 }
 
+// Variables for testing error paths
+var (
+	FailResourceMerge     bool
+	FailExporter          bool
+	FailMsgCounter        bool
+	FailBytesCounter      bool
+	FailDurationHistogram bool
+	FailCommitCounter     bool
+	FailErrorCounter      bool
+)
+
 var (
 	mp      *sdkmetric.MeterProvider
 	metrics *MQMetrics
@@ -55,7 +66,7 @@ func InitOTel(config OTelConfig) (*MQMetrics, error) {
 			semconv.DeploymentEnvironment(config.Environment),
 		),
 	)
-	if err != nil {
+	if err != nil || FailResourceMerge {
 		return nil, fmt.Errorf("falha ao criar recurso: %v", err)
 	}
 
@@ -64,7 +75,7 @@ func InitOTel(config OTelConfig) (*MQMetrics, error) {
 		otlpmetricgrpc.WithEndpoint(config.OTLPEndpoint),
 		otlpmetricgrpc.WithInsecure(),
 	)
-	if err != nil {
+	if err != nil || FailExporter {
 		return nil, fmt.Errorf("falha ao criar exportador OTLP: %v", err)
 	}
 
@@ -103,7 +114,7 @@ func InitOTel(config OTelConfig) (*MQMetrics, error) {
 		metric.WithDescription("Número total de mensagens transferidas"),
 		metric.WithUnit("{messages}"),
 	)
-	if err != nil {
+	if err != nil || FailMsgCounter {
 		return nil, fmt.Errorf("falha ao criar contador de mensagens: %v", err)
 	}
 
@@ -112,7 +123,7 @@ func InitOTel(config OTelConfig) (*MQMetrics, error) {
 		metric.WithDescription("Número total de bytes transferidos"),
 		metric.WithUnit("By"),
 	)
-	if err != nil {
+	if err != nil || FailBytesCounter {
 		return nil, fmt.Errorf("falha ao criar contador de bytes: %v", err)
 	}
 
@@ -121,7 +132,7 @@ func InitOTel(config OTelConfig) (*MQMetrics, error) {
 		metric.WithDescription("Duração da transferência de mensagens"),
 		metric.WithUnit("ms"),
 	)
-	if err != nil {
+	if err != nil || FailDurationHistogram {
 		return nil, fmt.Errorf("falha ao criar histograma de duração: %v", err)
 	}
 
@@ -130,7 +141,7 @@ func InitOTel(config OTelConfig) (*MQMetrics, error) {
 		metric.WithDescription("Número total de commits realizados"),
 		metric.WithUnit("{commits}"),
 	)
-	if err != nil {
+	if err != nil || FailCommitCounter {
 		return nil, fmt.Errorf("falha ao criar contador de commits: %v", err)
 	}
 
@@ -139,7 +150,7 @@ func InitOTel(config OTelConfig) (*MQMetrics, error) {
 		metric.WithDescription("Número total de erros ocorridos"),
 		metric.WithUnit("{errors}"),
 	)
-	if err != nil {
+	if err != nil || FailErrorCounter {
 		return nil, fmt.Errorf("falha ao criar contador de erros: %v", err)
 	}
 

--- a/internal/otelutils/otelutils_test.go
+++ b/internal/otelutils/otelutils_test.go
@@ -25,3 +25,47 @@ func TestInitOTelWithEndpoint(t *testing.T) {
 	}
 	Shutdown(context.Background())
 }
+
+func TestInitOTelFailures(t *testing.T) {
+	FailResourceMerge = true
+	if _, err := InitOTel(OTelConfig{OTLPEndpoint: "x"}); err == nil {
+		t.Fatalf("expected resource error")
+	}
+	FailResourceMerge = false
+
+	FailExporter = true
+	if _, err := InitOTel(OTelConfig{OTLPEndpoint: "x"}); err == nil {
+		t.Fatalf("expected exporter error")
+	}
+	FailExporter = false
+
+	FailMsgCounter = true
+	if _, err := InitOTel(OTelConfig{ServiceName: "s", ServiceVersion: "v", Environment: "e", OTLPEndpoint: "x"}); err == nil {
+		t.Fatalf("expected msg counter error")
+	}
+	FailMsgCounter = false
+
+	FailBytesCounter = true
+	if _, err := InitOTel(OTelConfig{ServiceName: "s", ServiceVersion: "v", Environment: "e", OTLPEndpoint: "x"}); err == nil {
+		t.Fatalf("expected bytes counter error")
+	}
+	FailBytesCounter = false
+
+	FailDurationHistogram = true
+	if _, err := InitOTel(OTelConfig{ServiceName: "s", ServiceVersion: "v", Environment: "e", OTLPEndpoint: "x"}); err == nil {
+		t.Fatalf("expected duration histogram error")
+	}
+	FailDurationHistogram = false
+
+	FailCommitCounter = true
+	if _, err := InitOTel(OTelConfig{ServiceName: "s", ServiceVersion: "v", Environment: "e", OTLPEndpoint: "x"}); err == nil {
+		t.Fatalf("expected commit counter error")
+	}
+	FailCommitCounter = false
+
+	FailErrorCounter = true
+	if _, err := InitOTel(OTelConfig{ServiceName: "s", ServiceVersion: "v", Environment: "e", OTLPEndpoint: "x"}); err == nil {
+		t.Fatalf("expected error counter error")
+	}
+	FailErrorCounter = false
+}

--- a/internal/transfer/transfer_test.go
+++ b/internal/transfer/transfer_test.go
@@ -64,3 +64,102 @@ func TestWorkerIdleExit(t *testing.T) {
 	go tm.worker(ctx, cancel, &wg, ch, context.Background(), nil)
 	wg.Wait()
 }
+
+func runWorker(opts TransferOptions) error {
+	tm := NewTransferManager(opts)
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	ch := make(chan workerResult, 1)
+	wg.Add(1)
+	go tm.worker(ctx, cancel, &wg, ch, context.Background(), nil)
+	time.Sleep(time.Millisecond)
+	cancel()
+	wg.Wait()
+	return (<-ch).err
+}
+
+func runWorkerSeq(opts TransferOptions, msgs []bool) error {
+	mqutils.Messages = msgs
+	tm := NewTransferManager(opts)
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	ch := make(chan workerResult, 1)
+	wg.Add(1)
+	go tm.worker(ctx, cancel, &wg, ch, context.Background(), nil)
+	wg.Wait()
+	return (<-ch).err
+}
+
+func TestWorkerFailures(t *testing.T) {
+	mqutils.ResetTestState()
+	mqutils.FailConnectCall = 1
+	if err := runWorker(TransferOptions{CommitInterval: 1, BufferSize: 1}); err == nil {
+		t.Fatalf("expected connect fail")
+	}
+	mqutils.ResetTestState()
+	mqutils.FailConnectCall = 2
+	if err := runWorker(TransferOptions{CommitInterval: 1, BufferSize: 1}); err == nil {
+		t.Fatalf("expected dest connect fail")
+	}
+	mqutils.ResetTestState()
+	mqutils.FailOpenCall = 1
+	if err := runWorker(TransferOptions{CommitInterval: 1, BufferSize: 1}); err == nil {
+		t.Fatalf("expected open fail")
+	}
+	mqutils.ResetTestState()
+	mqutils.FailOpenCall = 2
+	if err := runWorker(TransferOptions{CommitInterval: 1, BufferSize: 1}); err == nil {
+		t.Fatalf("expected src open fail")
+	}
+	mqutils.ResetTestState()
+	mqutils.FailPut = true
+	if err := runWorker(TransferOptions{CommitInterval: 1, BufferSize: 1}); err == nil {
+		t.Fatalf("expected put fail")
+	}
+	mqutils.ResetTestState()
+	mqutils.FailCommit = true
+	if err := runWorker(TransferOptions{CommitInterval: 1, BufferSize: 1}); err == nil {
+		t.Fatalf("expected commit fail")
+	}
+	mqutils.ResetTestState()
+	mqutils.FailGet = true
+	if err := runWorker(TransferOptions{CommitInterval: 1, BufferSize: 1}); err == nil {
+		t.Fatalf("expected get fail")
+	}
+}
+
+func TestWorkerCommitOnCancel(t *testing.T) {
+	mqutils.ResetTestState()
+	if err := runWorker(TransferOptions{CommitInterval: 100, BufferSize: 1}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestWorkerIdleCommit(t *testing.T) {
+	mqutils.ResetTestState()
+	err := runWorkerSeq(TransferOptions{CommitInterval: 2, BufferSize: 1}, []bool{true, false, false, false})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+}
+
+func TestRunCompletedAndFailed(t *testing.T) {
+	mqutils.ResetTestState()
+	mqutils.ReturnNilMessage = true
+	tm := NewTransferManager(TransferOptions{WorkerCount: 1})
+	tm.Start()
+	<-tm.done
+	if tm.GetStats().Status != StatusCompleted {
+		t.Fatalf("expected completed")
+	}
+
+	mqutils.ResetTestState()
+	mqutils.FailConnectCall = 1
+	tm2 := NewTransferManager(TransferOptions{WorkerCount: 1})
+	tm2.Start()
+	<-tm2.done
+	if tm2.GetStats().Status != StatusFailed {
+		t.Fatalf("expected failed")
+	}
+	mqutils.ResetTestState()
+}


### PR DESCRIPTION
## Summary
- adjust test helpers for MQ stubs
- add failure injection for otel utils
- extend handler, mqutil and transfer tests

## Testing
- `go test ./...`
- `go test ./... -coverprofile=cov.out`

------
https://chatgpt.com/codex/tasks/task_e_687e47942da4832597f638b3a560d05e