### PR TITLE
Increase Go coverage to 100%

### DIFF
--- a/internal/mqutils/mqutils_stub.go
+++ b/internal/mqutils/mqutils_stub.go
@@ -29,9 +29,11 @@ var (
 	openCalls        int
 	FailPut          bool
 	FailCommit       bool
+	FailCommitCall   int
 	FailGet          bool
 	Messages         []bool
 	msgIndex         int
+	CommitCalls      int
 )
 
 func ResetTestState() {
@@ -42,9 +44,11 @@ func ResetTestState() {
 	openCalls = 0
 	FailPut = false
 	FailCommit = false
+	FailCommitCall = 0
 	FailGet = false
 	Messages = nil
 	msgIndex = 0
+	CommitCalls = 0
 }
 
 func NewMQConnection(config MQConnectionConfig) *MQConnection {
@@ -112,8 +116,12 @@ func (c *MQConnection) PutMessage(queue struct{}, data []byte, md interface{}, c
 }
 
 func (c *MQConnection) Commit() error {
+	CommitCalls++
 	if FailCommit {
 		FailCommit = false
+		return errors.New("commit fail")
+	}
+	if FailCommitCall > 0 && CommitCalls == FailCommitCall {
 		return errors.New("commit fail")
 	}
 	return nil

--- a/internal/transfer/transfer_test.go
+++ b/internal/transfer/transfer_test.go
@@ -8,7 +8,10 @@ import (
 	"testing"
 	"time"
 
+	metricnoop "go.opentelemetry.io/otel/metric/noop"
+
 	"mq-transfer-go/internal/mqutils"
+	"mq-transfer-go/internal/otelutils"
 )
 
 func TestTransferCancel(t *testing.T) {
@@ -45,7 +48,7 @@ func TestWorkerCancel(t *testing.T) {
 	tm := NewTransferManager(TransferOptions{CommitInterval: 1, BufferSize: 1})
 	ctx, cancel := context.WithCancel(context.Background())
 	var wg sync.WaitGroup
-	ch := make(chan workerResult, 1)
+	ch := make(chan workerResult, 2)
 	wg.Add(1)
 	go tm.worker(ctx, cancel, &wg, ch, context.Background(), nil)
 	time.Sleep(2 * time.Millisecond)
@@ -59,7 +62,7 @@ func TestWorkerIdleExit(t *testing.T) {
 	defer func() { mqutils.ReturnNilMessage = false }()
 	ctx, cancel := context.WithCancel(context.Background())
 	var wg sync.WaitGroup
-	ch := make(chan workerResult, 1)
+	ch := make(chan workerResult, 2)
 	wg.Add(1)
 	go tm.worker(ctx, cancel, &wg, ch, context.Background(), nil)
 	wg.Wait()
@@ -69,7 +72,7 @@ func runWorker(opts TransferOptions) error {
 	tm := NewTransferManager(opts)
 	ctx, cancel := context.WithCancel(context.Background())
 	var wg sync.WaitGroup
-	ch := make(chan workerResult, 1)
+	ch := make(chan workerResult, 2)
 	wg.Add(1)
 	go tm.worker(ctx, cancel, &wg, ch, context.Background(), nil)
 	time.Sleep(time.Millisecond)
@@ -83,7 +86,7 @@ func runWorkerSeq(opts TransferOptions, msgs []bool) error {
 	tm := NewTransferManager(opts)
 	ctx, cancel := context.WithCancel(context.Background())
 	var wg sync.WaitGroup
-	ch := make(chan workerResult, 1)
+	ch := make(chan workerResult, 2)
 	wg.Add(1)
 	go tm.worker(ctx, cancel, &wg, ch, context.Background(), nil)
 	wg.Wait()
@@ -162,4 +165,148 @@ func TestRunCompletedAndFailed(t *testing.T) {
 		t.Fatalf("expected failed")
 	}
 	mqutils.ResetTestState()
+}
+
+func TestCommitIfNeeded(t *testing.T) {
+	tm := NewTransferManager(TransferOptions{CommitInterval: 1})
+	dest := &mqutils.MQConnection{}
+	src := &mqutils.MQConnection{}
+	count := 1
+	ch := make(chan workerResult, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	metrics := &otelutils.MQMetrics{}
+	m := metricnoop.NewMeterProvider().Meter("m")
+	c, _ := m.Int64Counter("c")
+	metrics.CommitCounter = c
+
+	mqutils.FailCommitCall = 1
+	if !tm.commitIfNeeded(&count, dest, src, metrics, ctx, ch, cancel) {
+		t.Fatalf("expected true")
+	}
+	if (<-ch).err == nil {
+		t.Fatalf("expected error")
+	}
+
+	mqutils.ResetTestState()
+	mqutils.FailCommitCall = 2
+	count = 1
+	if !tm.commitIfNeeded(&count, dest, src, metrics, ctx, ch, cancel) {
+		t.Fatalf("expected true for src fail")
+	}
+	if (<-ch).err == nil {
+		t.Fatalf("expected error 2")
+	}
+
+	mqutils.ResetTestState()
+	count = 1
+	if tm.commitIfNeeded(&count, dest, src, metrics, ctx, ch, cancel) {
+		t.Fatalf("unexpected true")
+	}
+	if count != 0 {
+		t.Fatalf("counter not reset")
+	}
+}
+
+func TestCommitRemainingAndHelpers(t *testing.T) {
+	tm := NewTransferManager(TransferOptions{CommitInterval: 1})
+	dest := &mqutils.MQConnection{}
+	src := &mqutils.MQConnection{}
+	mqutils.ResetTestState()
+	mqutils.CommitCalls = 0
+	tm.commitRemaining(2, dest, src)
+	if mqutils.CommitCalls != 2 {
+		t.Fatalf("expected two commits")
+	}
+
+	mqutils.CommitCalls = 0
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	ch := make(chan workerResult, 1)
+	if !tm.handleContextDone(ctx, 1, dest, src, ch) {
+		t.Fatalf("context done expected")
+	}
+	<-ch
+
+	idle := 2
+	commitCounter := 1
+	ctx2, cancel2 := context.WithCancel(context.Background())
+	cancel2()
+	ch2 := make(chan workerResult, 1)
+	if !tm.handleIdle(ctx2, &idle, &commitCounter, dest, src, ch2) {
+		t.Fatalf("idle exit")
+	}
+	<-ch2
+}
+
+func TestCopyBuffer(t *testing.T) {
+	tm := NewTransferManager(TransferOptions{BufferSize: 1})
+	b := tm.copyBuffer([]byte("abc"))
+	if string(b) != "abc" {
+		t.Fatalf("bad copy")
+	}
+	b[0] = 'x'
+	if string(b) == "abc" {
+		t.Fatalf("expected copy not alias")
+	}
+}
+
+func TestHandleIdleBranches(t *testing.T) {
+	tm := NewTransferManager(TransferOptions{CommitInterval: 1})
+	dest := &mqutils.MQConnection{}
+	src := &mqutils.MQConnection{}
+	idle := 3
+	commitCounter := 1
+	ch := make(chan workerResult, 1)
+	if !tm.handleIdle(context.Background(), &idle, &commitCounter, dest, src, ch) {
+		t.Fatalf("expected true when idle >=3")
+	}
+	<-ch
+
+	idle = 0
+	commitCounter = 1
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if !tm.handleIdle(ctx, &idle, &commitCounter, dest, src, ch) {
+		t.Fatalf("expected true on cancel")
+	}
+	<-ch
+
+	idle = 0
+	commitCounter = 0
+	start := time.Now()
+	if tm.handleIdle(context.Background(), &idle, &commitCounter, dest, src, ch) {
+		t.Fatalf("expected false")
+	}
+	if time.Since(start) < time.Second {
+		t.Fatalf("sleep not executed")
+	}
+}
+
+func TestWorkerWithMetrics(t *testing.T) {
+	mqutils.ResetTestState()
+	tm := NewTransferManager(TransferOptions{CommitInterval: 1, BufferSize: 1})
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	ch := make(chan workerResult, 2)
+	wg.Add(1)
+	m := metricnoop.NewMeterProvider().Meter("m")
+	msgC, _ := m.Int64Counter("msg")
+	byteC, _ := m.Int64Counter("bytes")
+	dur, _ := m.Float64Histogram("dur")
+	commitC, _ := m.Int64Counter("commit")
+	metrics := &otelutils.MQMetrics{MessagesTransferred: msgC, BytesTransferred: byteC, TransferDuration: dur, CommitCounter: commitC}
+	go tm.worker(ctx, cancel, &wg, ch, context.Background(), metrics)
+	time.Sleep(2 * time.Millisecond)
+	cancel()
+	wg.Wait()
+	<-ch
+}
+
+func TestSetStatsForTest(t *testing.T) {
+	tm := NewTransferManager(TransferOptions{})
+	tm.SetStatsForTest(Stats{Status: StatusFailed, Error: "e"})
+	s := tm.GetStats()
+	if s.Status != StatusFailed || s.Error != "e" {
+		t.Fatalf("stats not set")
+	}
 }


### PR DESCRIPTION
## Summary
- merge extra tests into existing files to satisfy review feedback
- cover additional branches for handlers, mqutils and transfer packages
- update test imports accordingly

## Testing
- `go test ./... -coverprofile coverage.out -covermode=count`


------
https://chatgpt.com/codex/tasks/task_e_687ec681b7c0832597400baa185ab1cf