### PR TITLE
Fix swagger host and health timestamp

### DIFF
--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -231,6 +231,10 @@ const docTemplate = `{
                 "version": {
                     "type": "string",
                     "example": "1.0.0"
+                },
+                "timestamp": {
+                    "type": "string",
+                    "example": "2025-06-04T00:15:30Z"
                 }
             }
         },
@@ -338,8 +342,10 @@ const docTemplate = `{
 
 // SwaggerInfo holds exported Swagger Info so clients can modify it
 var SwaggerInfo = &swag.Spec{
-	Version:          "1.0",
-	Host:             "localhost:8080",
+	Version: "1.0",
+	// Host is left empty so Swagger UI uses the host serving the docs,
+	// allowing the API to work behind any DNS or load balancer.
+	Host:             "",
 	BasePath:         "/",
 	Schemes:          []string{"http"},
 	Title:            "MQ Transfer API",

--- a/api/docs/swagger.json
+++ b/api/docs/swagger.json
@@ -18,7 +18,7 @@
         },
         "version": "1.0"
     },
-    "host": "localhost:8080",
+    "host": "",
     "basePath": "/",
     "paths": {
         "/api/v1/health": {
@@ -228,6 +228,10 @@
                 "version": {
                     "type": "string",
                     "example": "1.0.0"
+                },
+                "timestamp": {
+                    "type": "string",
+                    "example": "2025-06-04T00:15:30Z"
                 }
             }
         },

--- a/api/docs/swagger.yaml
+++ b/api/docs/swagger.yaml
@@ -30,6 +30,9 @@ definitions:
       version:
         example: 1.0.0
         type: string
+      timestamp:
+        example: 2025-06-04T00:15:30Z
+        type: string
     type: object
   models.TransferRequest:
     properties:
@@ -103,7 +106,7 @@ definitions:
         example: in_progress
         type: string
     type: object
-host: localhost:8080
+host: ""
 info:
   contact:
     email: support@example.com

--- a/api/handlers/health.go
+++ b/api/handlers/health.go
@@ -15,8 +15,6 @@ import (
 // @Success 200 {object} models.HealthResponse
 // @Router /api/v1/health [get]
 func HealthCheck(c *gin.Context) {
-	c.JSON(http.StatusOK, models.HealthResponse{
-		Status:  "ok",
-		Version: "1.0.0",
-	})
+	resp := models.NewHealthResponse("ok", "1.0.0")
+	c.JSON(http.StatusOK, resp)
 }

--- a/api/models/models.go
+++ b/api/models/models.go
@@ -43,6 +43,7 @@ type TransferStatus struct {
 
 // HealthResponse representa a resposta do endpoint de health check
 type HealthResponse struct {
-	Status  string `json:"status" example:"ok" swaggertype:"string"`
-	Version string `json:"version" example:"1.0.0" swaggertype:"string"`
+	Status    string `json:"status" example:"ok" swaggertype:"string"`
+	Version   string `json:"version" example:"1.0.0" swaggertype:"string"`
+	Timestamp string `json:"timestamp" example:"2025-06-04T00:15:30Z" swaggertype:"string"`
 }

--- a/api/models/utils.go
+++ b/api/models/utils.go
@@ -1,6 +1,12 @@
 package models
 
+import "time"
+
 // NewHealthResponse returns a HealthResponse initialized with the given status and version.
 func NewHealthResponse(status, version string) HealthResponse {
-	return HealthResponse{Status: status, Version: version}
+	return HealthResponse{
+		Status:    status,
+		Version:   version,
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+	}
 }

--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 	"github.com/gin-gonic/gin"
 	swaggerFiles "github.com/swaggo/files"
 	ginSwagger "github.com/swaggo/gin-swagger"
-	_ "mq-transfer-go/api/docs"
+	docs "mq-transfer-go/api/docs"
 	"mq-transfer-go/api/handlers"
 	"mq-transfer-go/internal/otelutils"
 )
@@ -54,6 +54,8 @@ func main() {
 	defer stop()
 
 	r := gin.Default()
+	// Use empty host so swagger calls the same host that served the docs
+	docs.SwaggerInfo.Host = ""
 	v1 := r.Group("/api/v1")
 	{
 		v1.POST("/transfer", handlers.StartTransfer)
@@ -76,7 +78,7 @@ func main() {
 	}()
 
 	log.Println("Servidor iniciado na porta", serverAddr)
-	log.Println("Documentação Swagger disponível em: http://localhost" + serverAddr + "/swagger/index.html")
+	log.Println("Documentação Swagger disponível em: /swagger/index.html")
 
 	<-ctx.Done()
 	log.Println("Desligando servidor...")


### PR DESCRIPTION
## Summary
- support serving Swagger UI under any host by leaving `SwaggerInfo.Host` empty
- show timestamp in health check response

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6880f3aa8b6083259da4fac4cfbbbf4e