### PR TITLE
Add DB health ping and improve tests

### DIFF
--- a/api/handlers/health.go
+++ b/api/handlers/health.go
@@ -7,6 +7,15 @@ import (
 	"mq-transfer-go/api/models"
 )
 
+// Pinger defines the behaviour required to verify a store connection.
+type Pinger interface {
+	Ping() error
+}
+
+// HealthStore is used by the handler to verify database health. It can be
+// replaced in tests.
+var HealthStore Pinger
+
 // HealthCheck retorna o status geral da aplicação
 // @Summary Health Check
 // @Description Retorna informacoes de saude da aplicacao
@@ -15,6 +24,13 @@ import (
 // @Success 200 {object} models.HealthResponse
 // @Router /api/v1/health [get]
 func HealthCheck(c *gin.Context) {
+	status := http.StatusOK
 	resp := models.NewHealthResponse("ok", "1.0.0")
-	c.JSON(http.StatusOK, resp)
+	if HealthStore != nil {
+		if err := HealthStore.Ping(); err != nil {
+			resp.Status = "db_error"
+			status = http.StatusInternalServerError
+		}
+	}
+	c.JSON(status, resp)
 }

--- a/api/handlers/health_test.go
+++ b/api/handlers/health_test.go
@@ -8,13 +8,32 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+type pingStore struct{ err error }
+
+func (p pingStore) Ping() error { return p.err }
+
 func TestHealthCheck(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
+	HealthStore = pingStore{}
+	defer func() { HealthStore = nil }()
 
 	HealthCheck(c)
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestHealthCheckFail(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	HealthStore = pingStore{err: http.ErrServerClosed}
+	defer func() { HealthStore = nil }()
+
+	HealthCheck(c)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Code)
 	}
 }

--- a/api/handlers/helpers_test.go
+++ b/api/handlers/helpers_test.go
@@ -1,0 +1,70 @@
+package handlers
+
+import (
+	"database/sql"
+	"errors"
+	"mq-transfer-go/transferstore"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestResolveHelpers(t *testing.T) {
+	os.Setenv("BUFFER_SIZE", "2048")
+	if v := resolveBufferSize(0); v != 2048 {
+		t.Fatalf("buf env not used: %d", v)
+	}
+	if v := resolveBufferSize(1024); v != 1024 {
+		t.Fatalf("buf direct")
+	}
+	os.Setenv("BUFFER_SIZE", "bad")
+	if v := resolveBufferSize(0); v != 1048576 {
+		t.Fatalf("default not used")
+	}
+	os.Unsetenv("BUFFER_SIZE")
+
+	os.Setenv("WORKER_COUNT", "2")
+	if v := resolveWorkerCount(); v != 2 {
+		t.Fatalf("worker env")
+	}
+	os.Setenv("WORKER_COUNT", "bad")
+	if v := resolveWorkerCount(); v != 0 {
+		t.Fatalf("worker default")
+	}
+	os.Unsetenv("WORKER_COUNT")
+
+	os.Setenv("BATCH_SIZE", "5")
+	if v := resolveCommitInterval(0); v != 5 {
+		t.Fatalf("commit env")
+	}
+	if v := resolveCommitInterval(3); v != 3 {
+		t.Fatalf("commit direct")
+	}
+	os.Setenv("BATCH_SIZE", "bad")
+	if v := resolveCommitInterval(0); v != 10 {
+		t.Fatalf("commit default")
+	}
+	os.Unsetenv("BATCH_SIZE")
+}
+
+func TestIsNotFound(t *testing.T) {
+	if isNotFound(nil) {
+		t.Fatalf("nil")
+	}
+	if !isNotFound(sql.ErrNoRows) {
+		t.Fatalf("sql err")
+	}
+	if !isNotFound(errors.New("not found")) {
+		t.Fatalf("text err")
+	}
+}
+
+func TestToStatus(t *testing.T) {
+	now := time.Now().UTC()
+	end := now.Add(time.Minute)
+	req := transferstore.TransferRequest{RequestID: "1", Status: "s", StartTime: now, EndTime: &end, BytesTransferred: 2, MessagesTransferred: 3}
+	st := toStatus(req)
+	if st.RequestID != "1" || st.Status != "s" || st.EndTime == "" {
+		t.Fatalf("bad status: %+v", st)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -75,6 +75,9 @@ func main() {
 		}
 	}
 	handler := handlers.NewTransferHandler(store)
+	if hs, ok := store.(handlers.Pinger); ok {
+		handlers.HealthStore = hs
+	}
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 

--- a/transferstore/dynamo/dynamo.go
+++ b/transferstore/dynamo/dynamo.go
@@ -113,3 +113,10 @@ func (d *DynamoStore) List() ([]transferstore.TransferRequest, error) {
 	}
 	return reqs, nil
 }
+
+// Ping verifies connectivity with DynamoDB by performing a lightweight scan.
+func (d *DynamoStore) Ping() error {
+	limit := int32(1)
+	_, err := d.client.Scan(context.Background(), &dynamodb.ScanInput{TableName: &d.table, Limit: &limit})
+	return err
+}

--- a/transferstore/dynamo/dynamo_test.go
+++ b/transferstore/dynamo/dynamo_test.go
@@ -123,6 +123,10 @@ func TestDynamoStore(t *testing.T) {
 	if err != nil || len(list) != 1 {
 		t.Fatalf("list: %v %v", len(list), err)
 	}
+
+	if err := store.Ping(); err != nil {
+		t.Fatalf("ping: %v", err)
+	}
 }
 
 func TestDynamoStoreErrors(t *testing.T) {
@@ -143,5 +147,9 @@ func TestDynamoStoreErrors(t *testing.T) {
 	}
 	if _, err := store.List(); err == nil {
 		t.Fatal("expected error")
+	}
+
+	if err := store.Ping(); err == nil {
+		t.Fatal("expected ping error")
 	}
 }

--- a/transferstore/sqlite/sqlite.go
+++ b/transferstore/sqlite/sqlite.go
@@ -144,3 +144,8 @@ func nilIfTime(t *time.Time) interface{} {
 	}
 	return t.Format(time.RFC3339)
 }
+
+// Ping verifies the database connection is alive.
+func (s *SQLiteStore) Ping() error {
+	return s.db.Ping()
+}

--- a/transferstore/sqlite/sqlite_test.go
+++ b/transferstore/sqlite/sqlite_test.go
@@ -65,4 +65,12 @@ func TestSQLiteStore(t *testing.T) {
 	if v := nilIfTime(&end); v == nil {
 		t.Fatalf("nilIfTime value")
 	}
+
+	if err := store.Ping(); err != nil {
+		t.Fatalf("ping failed: %v", err)
+	}
+	store.db.Close()
+	if err := store.Ping(); err == nil {
+		t.Fatalf("expected ping error after close")
+	}
 }


### PR DESCRIPTION
## Summary
- add Pinger interface and global health store for DB checks
- implement `Ping` in SQLite and Dynamo stores
- set `HealthStore` from main when server starts
- extend health handler to report DB status
- add missing helper tests and update existing tests

## Testing
- `go test ./... -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6887f607b8188325ae6bbf6fdc29235c