### PR TITLE
Enhance concurrency handling

### DIFF
--- a/api/handlers/transfer.go
+++ b/api/handlers/transfer.go
@@ -20,13 +20,12 @@ import (
 // TransferHandler holds dependencies for transfer related endpoints.
 type TransferHandler struct {
 	store    transferstore.TransferStore
-	managers map[string]*transfer.TransferManager
-	mu       *sync.RWMutex
+	managers sync.Map // key string -> *transfer.TransferManager
 }
 
 // NewTransferHandler creates a new handler with the given store.
 func NewTransferHandler(s transferstore.TransferStore) *TransferHandler {
-	return &TransferHandler{store: s, managers: make(map[string]*transfer.TransferManager), mu: &sync.RWMutex{}}
+	return &TransferHandler{store: s}
 }
 
 // monitorInterval controls how often the monitor goroutine checks transfer status.
@@ -182,9 +181,7 @@ func (h *TransferHandler) StartTransfer(c *gin.Context) {
 		return
 	}
 
-	h.mu.Lock()
-	h.managers[requestID] = transferMgr
-	h.mu.Unlock()
+	h.managers.Store(requestID, transferMgr)
 
 	go h.monitorTransfer(requestID, transferMgr)
 
@@ -211,9 +208,7 @@ func (h *TransferHandler) monitorTransfer(requestID string, transferMgr *transfe
 				errMsg = &stats.Error
 			}
 			_ = h.store.UpdateStatus(requestID, stats.Status, &end, errMsg)
-			h.mu.Lock()
-			delete(h.managers, requestID)
-			h.mu.Unlock()
+			h.managers.Delete(requestID)
 			return
 		}
 	}
@@ -289,10 +284,8 @@ func (h *TransferHandler) CancelTransfer(c *gin.Context) {
 		return
 	}
 
-	h.mu.RLock()
-	mgr, ok := h.managers[requestID]
-	h.mu.RUnlock()
-	if ok {
+	if v, ok := h.managers.Load(requestID); ok {
+		mgr := v.(*transfer.TransferManager)
 		mgr.Stop()
 	}
 	now := time.Now().UTC()
@@ -301,9 +294,7 @@ func (h *TransferHandler) CancelTransfer(c *gin.Context) {
 		return
 	}
 
-	h.mu.Lock()
-	delete(h.managers, requestID)
-	h.mu.Unlock()
+	h.managers.Delete(requestID)
 
 	c.JSON(http.StatusOK, models.TransferResponse{Status: transfer.StatusCancelled, RequestID: requestID})
 }

--- a/api/handlers/transfer_test.go
+++ b/api/handlers/transfer_test.go
@@ -78,9 +78,7 @@ func TestStartAndCancelTransfer(t *testing.T) {
 	var resp models.TransferResponse
 	_ = json.Unmarshal(w.Body.Bytes(), &resp)
 
-	h.mu.Lock()
-	h.managers[resp.RequestID] = transfer.NewTransferManager(transfer.TransferOptions{})
-	h.mu.Unlock()
+	h.managers.Store(resp.RequestID, transfer.NewTransferManager(transfer.TransferOptions{}))
 
 	store.EXPECT().GetByID(resp.RequestID).Return(transferstore.TransferRequest{RequestID: resp.RequestID, Status: transfer.StatusInProgress}, nil)
 	store.EXPECT().UpdateStatus(resp.RequestID, transfer.StatusCancelled, gomock.Any(), gomock.Nil()).Return(nil)

--- a/internal/transfer/transfer.go
+++ b/internal/transfer/transfer.go
@@ -83,17 +83,26 @@ func NewTransferManager(opts TransferOptions) *TransferManager {
 }
 
 // Start begins the transfer asynchronously.
+// Start begins the transfer asynchronously using a background context.
 func (tm *TransferManager) Start() {
-	go tm.run()
+	tm.StartContext(context.Background())
 }
 
-func (tm *TransferManager) run() {
+// StartContext begins the transfer using the provided parent context.
+func (tm *TransferManager) StartContext(ctx context.Context) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	go tm.run(ctx)
+}
+
+func (tm *TransferManager) run(parent context.Context) {
 	tm.mu.Lock()
 	tm.stats.Status = StatusInProgress
 	tm.mu.Unlock()
 	defer close(tm.done)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(parent)
 	defer cancel()
 
 	var wg sync.WaitGroup
@@ -105,8 +114,12 @@ func (tm *TransferManager) run() {
 	}
 
 	go func() {
-		<-tm.quit
-		cancel()
+		select {
+		case <-tm.quit:
+			cancel()
+		case <-parent.Done():
+			cancel()
+		}
 	}()
 
 	wg.Wait()


### PR DESCRIPTION
## Summary
- allow TransferManager to start with parent context and cancel on context cancel
- use sync.Map in TransferHandler to avoid lock contention

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_688958c644e88325b73269fe9db0f0e3