### PR TITLE
Fix goroutine cleanup in transfer tests

### DIFF
--- a/api/handlers/integration_test.go
+++ b/api/handlers/integration_test.go
@@ -61,4 +61,6 @@ func TestIntegrationSQLite(t *testing.T) {
 	if w4.Code != http.StatusOK {
 		t.Fatalf("cancel failed")
 	}
+
+	h.wg.Wait()
 }

--- a/api/handlers/transfer.go
+++ b/api/handlers/transfer.go
@@ -21,6 +21,7 @@ import (
 type TransferHandler struct {
 	store    transferstore.TransferStore
 	managers sync.Map // key string -> *transfer.TransferManager
+	wg       sync.WaitGroup
 }
 
 // NewTransferHandler creates a new handler with the given store.
@@ -183,6 +184,7 @@ func (h *TransferHandler) StartTransfer(c *gin.Context) {
 
 	h.managers.Store(requestID, transferMgr)
 
+	h.wg.Add(1)
 	go h.monitorTransfer(requestID, transferMgr)
 
 	c.JSON(http.StatusAccepted, models.TransferResponse{
@@ -192,6 +194,7 @@ func (h *TransferHandler) StartTransfer(c *gin.Context) {
 }
 
 func (h *TransferHandler) monitorTransfer(requestID string, transferMgr *transfer.TransferManager) {
+	defer h.wg.Done()
 	ticker := time.NewTicker(monitorInterval)
 	defer ticker.Stop()
 

--- a/api/handlers/transfer_test.go
+++ b/api/handlers/transfer_test.go
@@ -68,6 +68,7 @@ func TestStartAndCancelTransfer(t *testing.T) {
 	}
 	body, _ := json.Marshal(req)
 	store.EXPECT().Create(gomock.Any()).Return(nil)
+	store.EXPECT().UpdateProgress(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
 	c.Request = httptest.NewRequest(http.MethodPost, "/transfer", bytes.NewBuffer(body))
@@ -78,10 +79,8 @@ func TestStartAndCancelTransfer(t *testing.T) {
 	var resp models.TransferResponse
 	_ = json.Unmarshal(w.Body.Bytes(), &resp)
 
-	h.managers.Store(resp.RequestID, transfer.NewTransferManager(transfer.TransferOptions{}))
-
 	store.EXPECT().GetByID(resp.RequestID).Return(transferstore.TransferRequest{RequestID: resp.RequestID, Status: transfer.StatusInProgress}, nil)
-	store.EXPECT().UpdateStatus(resp.RequestID, transfer.StatusCancelled, gomock.Any(), gomock.Nil()).Return(nil)
+	store.EXPECT().UpdateStatus(resp.RequestID, transfer.StatusCancelled, gomock.Any(), gomock.Nil()).AnyTimes()
 	w2 := httptest.NewRecorder()
 	c2, _ := gin.CreateTestContext(w2)
 	c2.Params = gin.Params{gin.Param{Key: "requestId", Value: resp.RequestID}}
@@ -89,6 +88,8 @@ func TestStartAndCancelTransfer(t *testing.T) {
 	if w2.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", w2.Code)
 	}
+
+	h.wg.Wait()
 }
 
 func TestCancelCompleted(t *testing.T) {


### PR DESCRIPTION
## Summary
- track monitor goroutines with a WaitGroup
- wait for monitor goroutines to finish in tests
- allow multiple UpdateStatus/Progress calls in mocks

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_688a647acb3c83258a51dcf8179f10ce