### PR TITLE
feat: add pagination to transfers listing

### DIFF
--- a/api/docs/openapi.json
+++ b/api/docs/openapi.json
@@ -190,6 +190,28 @@
                     "transfer"
                 ],
                 "summary": "Listar todas as transferências",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "limit",
+                        "schema": {
+                            "type": "integer",
+                            "default": 100,
+                            "minimum": 1
+                        },
+                        "description": "Número máximo de registros a retornar"
+                    },
+                    {
+                        "in": "query",
+                        "name": "offset",
+                        "schema": {
+                            "type": "integer",
+                            "default": 0,
+                            "minimum": 0
+                        },
+                        "description": "Quantidade de registros a pular antes de iniciar a lista"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "Lista de transferências",

--- a/api/docs/openapi.yaml
+++ b/api/docs/openapi.yaml
@@ -118,6 +118,21 @@ paths:
   /api/v1/transfers:
     get:
       description: Retorna uma lista com todas as transferências e seus status
+      parameters:
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            default: 100
+            minimum: 1
+          description: Número máximo de registros a retornar
+        - in: query
+          name: offset
+          schema:
+            type: integer
+            default: 0
+            minimum: 0
+          description: Quantidade de registros a pular antes de iniciar a lista
       responses:
         "200":
           description: Lista de transferências

--- a/api/handlers/transfer.go
+++ b/api/handlers/transfer.go
@@ -248,7 +248,19 @@ func (h *TransferHandler) GetTransferStatus(c *gin.Context) {
 // @Success 200 {array} models.TransferStatus "Lista de transferências"
 // @Router /api/v1/transfers [get]
 func (h *TransferHandler) ListTransfers(c *gin.Context) {
-	reqs, err := h.store.List()
+	limit := 100
+	if lStr := c.Query("limit"); lStr != "" {
+		if l, err := strconv.Atoi(lStr); err == nil && l > 0 {
+			limit = l
+		}
+	}
+	offset := 0
+	if oStr := c.Query("offset"); oStr != "" {
+		if o, err := strconv.Atoi(oStr); err == nil && o >= 0 {
+			offset = o
+		}
+	}
+	reqs, err := h.store.List(offset, limit)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, models.TransferResponse{Status: transfer.StatusFailed, Error: "erro ao listar"})
 		return

--- a/api/handlers/transfer_test.go
+++ b/api/handlers/transfer_test.go
@@ -112,10 +112,11 @@ func TestListTransfers(t *testing.T) {
 	h, store, ctrl := newMockHandler(t)
 	defer ctrl.Finish()
 	list := []transferstore.TransferRequest{{RequestID: "a"}, {RequestID: "b"}}
-	store.EXPECT().List().Return(list, nil)
+	store.EXPECT().List(0, 100).Return(list, nil)
 
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
 	h.ListTransfers(c)
 	if w.Code != http.StatusOK {
 		t.Fatalf("unexpected status")
@@ -124,5 +125,26 @@ func TestListTransfers(t *testing.T) {
 	_ = json.Unmarshal(w.Body.Bytes(), &out)
 	if len(out) != 2 {
 		t.Fatalf("expected 2 entries")
+	}
+}
+
+func TestListTransfersWithParams(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h, store, ctrl := newMockHandler(t)
+	defer ctrl.Finish()
+	list := []transferstore.TransferRequest{{RequestID: "c"}}
+	store.EXPECT().List(5, 1).Return(list, nil)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/?limit=1&offset=5", nil)
+	h.ListTransfers(c)
+	if w.Code != http.StatusOK {
+		t.Fatalf("unexpected status")
+	}
+	var out []models.TransferStatus
+	_ = json.Unmarshal(w.Body.Bytes(), &out)
+	if len(out) != 1 || out[0].RequestID != "c" {
+		t.Fatalf("expected filtered result")
 	}
 }

--- a/transferstore/dynamo/dynamo.go
+++ b/transferstore/dynamo/dynamo.go
@@ -95,15 +95,27 @@ func (d *DynamoStore) UpdateProgress(id string, messagesTransferred int, bytesTr
 		Run()
 }
 
-func (d *DynamoStore) List() ([]transferstore.TransferRequest, error) {
+func (d *DynamoStore) List(offset, limit int) ([]transferstore.TransferRequest, error) {
 	if d.closed {
 		return nil, errors.New("store closed")
 	}
 	var reqs []transferstore.TransferRequest
-	if err := d.table.Scan().All(&reqs); err != nil {
+	scan := d.table.Scan()
+	if limit > 0 {
+		// fetch enough items to satisfy offset + limit
+		scan = scan.Limit(int64(offset + limit))
+	}
+	if err := scan.All(&reqs); err != nil {
 		return nil, err
 	}
-	return reqs, nil
+	if offset >= len(reqs) {
+		return []transferstore.TransferRequest{}, nil
+	}
+	end := len(reqs)
+	if limit > 0 && offset+limit < end {
+		end = offset + limit
+	}
+	return reqs[offset:end], nil
 }
 
 func (d *DynamoStore) Ping() error {

--- a/transferstore/dynamo/dynamo_test.go
+++ b/transferstore/dynamo/dynamo_test.go
@@ -178,7 +178,7 @@ func TestDynamoStore(t *testing.T) {
 	if got.Status != "completed" || got.Error != msg {
 		t.Fatalf("status wrong: %+v", got)
 	}
-	list, err := store.List()
+	list, err := store.List(0, 10)
 	if err != nil || len(list) != 1 {
 		t.Fatalf("list: %v %v", len(list), err)
 	}
@@ -211,7 +211,7 @@ func TestDynamoStoreErrors(t *testing.T) {
 	if err := store.UpdateProgress("1", 1, 1); err == nil {
 		t.Fatal("expected error")
 	}
-	if _, err := store.List(); err == nil {
+	if _, err := store.List(0, 10); err == nil {
 		t.Fatal("expected error")
 	}
 	if err := store.Ping(); err == nil {

--- a/transferstore/mock_transferstore/mock_store.go
+++ b/transferstore/mock_transferstore/mock_store.go
@@ -65,18 +65,18 @@ func (mr *MockTransferStoreMockRecorder) GetByID(arg0 interface{}) *gomock.Call 
 }
 
 // List mocks base method.
-func (m *MockTransferStore) List() ([]transferstore.TransferRequest, error) {
+func (m *MockTransferStore) List(arg0, arg1 int) ([]transferstore.TransferRequest, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "List")
+	ret := m.ctrl.Call(m, "List", arg0, arg1)
 	ret0, _ := ret[0].([]transferstore.TransferRequest)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // List indicates an expected call of List.
-func (mr *MockTransferStoreMockRecorder) List() *gomock.Call {
+func (mr *MockTransferStoreMockRecorder) List(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockTransferStore)(nil).List))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockTransferStore)(nil).List), arg0, arg1)
 }
 
 // UpdateProgress mocks base method.

--- a/transferstore/sqlite/sqlite.go
+++ b/transferstore/sqlite/sqlite.go
@@ -97,9 +97,16 @@ func (s *SQLiteStore) UpdateProgress(id string, messagesTransferred int, bytesTr
 		}).Error
 }
 
-func (s *SQLiteStore) List() ([]transferstore.TransferRequest, error) {
+func (s *SQLiteStore) List(offset, limit int) ([]transferstore.TransferRequest, error) {
 	var models []transferRequestModel
-	if err := s.db.Find(&models).Error; err != nil {
+	q := s.db
+	if offset > 0 {
+		q = q.Offset(offset)
+	}
+	if limit > 0 {
+		q = q.Limit(limit)
+	}
+	if err := q.Find(&models).Error; err != nil {
 		return nil, err
 	}
 	results := make([]transferstore.TransferRequest, 0, len(models))

--- a/transferstore/sqlite/sqlite_test.go
+++ b/transferstore/sqlite/sqlite_test.go
@@ -51,7 +51,7 @@ func TestSQLiteStore(t *testing.T) {
 	if fetched.Status != "completed" || fetched.Error != errMsg {
 		t.Fatalf("status not updated: %+v", fetched)
 	}
-	list, err := store.List()
+	list, err := store.List(0, 10)
 	if err != nil || len(list) != 1 {
 		t.Fatalf("list failed: %v %v", len(list), err)
 	}

--- a/transferstore/store.go
+++ b/transferstore/store.go
@@ -37,5 +37,8 @@ type TransferStore interface {
 	GetByID(id string) (TransferRequest, error)
 	UpdateStatus(id, status string, endTime *time.Time, errorMsg *string) error
 	UpdateProgress(id string, messagesTransferred int, bytesTransferred int) error
-	List() ([]TransferRequest, error)
+	// List returns transfer records with pagination support.
+	// offset specifies how many records to skip before beginning to return results.
+	// limit defines the maximum number of records to return.
+	List(offset, limit int) ([]TransferRequest, error)
 }


### PR DESCRIPTION
## Summary
- support limit/offset in transfer store interface
- add pagination query params to list transfers endpoint and docs
- cover new behavior with tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6895f8e65f0083258df914a957a3cfb2